### PR TITLE
feat: add launch and exact-time targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If `ANTHROPIC_API_KEY` is set, Claude will refine the time window. Otherwise a b
 
 ### `snipe` — snipe from a saved config or inline targets
 
-Loads a JSON config from `recon`, or accepts inline `--target` flags, and starts polling immediately.
+Loads a JSON config from `recon`, or accepts inline `--target` flags, compact `--date` lists, and optional deterministic `--exact-time` values.
 
 ```bash
 # Live snipe from a config file
@@ -80,6 +80,13 @@ python main.py snipe --config canlis.json
 python main.py snipe canlis \
   --target 2026-03-14 "5:00 PM" "9:30 PM" 2 \
   --target 2026-03-21 "5:00 PM" "9:30 PM" 2
+
+# Compact deterministic mode: try exact start times on a list of dates
+python main.py snipe taneda \
+  --date 2026-06-17 \
+  --date 2026-06-18 \
+  --exact-time "5:15 PM" \
+  --exact-time "7:45 PM"
 
 # Dry-run: finds slots but does not click them
 python main.py snipe --config canlis.json --dry-run
@@ -100,14 +107,26 @@ python main.py run canlis --size 2
 # Also save the discovered config
 python main.py run canlis --size 2 --save canlis.json
 
-# Release mode: wait until 10:00 AM Chicago time, then fire
-python main.py run canlis --size 2 --release-at 10:00 --timezone America/Chicago
+# Release mode: wait until 11:00 in local machine time, then fire
+python main.py run canlis --size 2 --release-at 11:00
+
+# Taneda-style launch mode: only target newly released dates and hit exact slots
+python main.py run taneda \
+  --size 2 \
+  --release-at 11:00 \
+  --newly-released-only \
+  --date 2026-06-17 \
+  --date 2026-06-18 \
+  --exact-time "5:15 PM" \
+  --exact-time "7:45 PM"
 
 # Dry-run with custom interval
 python main.py run canlis --size 2 --dry-run --interval 15
 ```
 
-The `run` subcommand accepts all the same flags as `snipe` (`--interval`, `--max-duration`, `--release-at`, `--timezone`, `--cookies-file`, `--login`, `--prompt-login`, `--json`, `--dry-run`).
+`--release-at` uses local machine time by default. `--timezone` remains available as an advanced override, but most local runs do not need it.
+
+The `run` subcommand accepts all the same flags as `snipe` (`--interval`, `--max-duration`, `--release-at`, `--newly-released-only`, `--date`, `--exact-time`, `--timezone`, `--cookies-file`, `--login`, `--prompt-login`, `--json`, `--dry-run`).
 
 ---
 
@@ -167,11 +186,14 @@ All optional. Set in your shell or a `.env` file (loaded manually — no `python
 | Flag              | Description                                                        |
 |-------------------|--------------------------------------------------------------------|
 | `--target DATE EARLIEST LATEST SIZE` | Inline target (repeatable). Example: `--target 2026-03-14 "5:00 PM" "9:30 PM" 2` |
+| `--date YYYY-MM-DD` | Compact date filter (repeatable) |
+| `--exact-time "H:MM AM/PM"` | Deterministic exact start time (repeatable) |
 | `--config FILE`   | JSON config file from `recon`                                      |
 | `--interval SECONDS` | Poll interval in seconds (default: 30)                          |
 | `--max-duration MINUTES` | Stop after this many minutes (0 = unlimited)                |
-| `--release-at HH:MM` | Start sniping at this time of day                               |
-| `--timezone TZ`   | Timezone for `--release-at` (e.g. `America/Chicago`)               |
+| `--release-at HH:MM` | Start sniping at this local machine time                       |
+| `--newly-released-only` | In launch mode, target only dates that appear after release |
+| `--timezone TZ`   | Optional advanced override for `--release-at`                      |
 | `--cookies-file FILE` | Path to Netscape cookies file for authentication               |
 | `--login`         | Perform interactive browser login before sniping                   |
 | `--prompt-login`  | After cart add, prompt for Tock credentials to tie cart to your account |

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If `ANTHROPIC_API_KEY` is set, Claude will refine the time window. Otherwise a b
 
 ### `snipe` — snipe from a saved config or inline targets
 
-Loads a JSON config from `recon`, or accepts inline `--target` flags, compact `--date` lists, and optional deterministic `--exact-time` values.
+Loads a JSON config from `recon`, or accepts inline `--target` flags, compact `--dates` lists, and optional deterministic `--exact-times` values.
 
 ```bash
 # Live snipe from a config file
@@ -83,10 +83,8 @@ python main.py snipe canlis \
 
 # Compact deterministic mode: try exact start times on a list of dates
 python main.py snipe taneda \
-  --date 2026-06-17 \
-  --date 2026-06-18 \
-  --exact-time "5:15 PM" \
-  --exact-time "7:45 PM"
+  --dates 2026-06-17,2026-06-18 \
+  --exact-times "5:15 PM,7:45 PM"
 
 # Dry-run: finds slots but does not click them
 python main.py snipe --config canlis.json --dry-run
@@ -115,10 +113,8 @@ python main.py run taneda \
   --size 2 \
   --release-at 11:00 \
   --newly-released-only \
-  --date 2026-06-17 \
-  --date 2026-06-18 \
-  --exact-time "5:15 PM" \
-  --exact-time "7:45 PM"
+  --dates 2026-06-17,2026-06-18 \
+  --exact-times "5:15 PM,7:45 PM"
 
 # Dry-run with custom interval
 python main.py run canlis --size 2 --dry-run --interval 15
@@ -126,7 +122,7 @@ python main.py run canlis --size 2 --dry-run --interval 15
 
 `--release-at` uses local machine time by default. `--timezone` remains available as an advanced override, but most local runs do not need it.
 
-The `run` subcommand accepts all the same flags as `snipe` (`--interval`, `--max-duration`, `--release-at`, `--newly-released-only`, `--date`, `--exact-time`, `--timezone`, `--cookies-file`, `--login`, `--prompt-login`, `--json`, `--dry-run`).
+The `run` subcommand accepts all the same flags as `snipe` (`--interval`, `--max-duration`, `--release-at`, `--newly-released-only`, `--dates`, `--exact-times`, `--timezone`, `--cookies-file`, `--login`, `--prompt-login`, `--json`, `--dry-run`).
 
 ---
 
@@ -186,8 +182,10 @@ All optional. Set in your shell or a `.env` file (loaded manually — no `python
 | Flag              | Description                                                        |
 |-------------------|--------------------------------------------------------------------|
 | `--target DATE EARLIEST LATEST SIZE` | Inline target (repeatable). Example: `--target 2026-03-14 "5:00 PM" "9:30 PM" 2` |
-| `--date YYYY-MM-DD` | Compact date filter (repeatable) |
-| `--exact-time "H:MM AM/PM"` | Deterministic exact start time (repeatable) |
+| `--dates YYYY-MM-DD,YYYY-MM-DD` | Comma-separated compact date filter |
+| `--exact-times "H:MM AM/PM,H:MM AM/PM"` | Comma-separated deterministic exact start times |
+| `--date YYYY-MM-DD` | Legacy repeatable date flag, still supported |
+| `--exact-time "H:MM AM/PM"` | Legacy repeatable exact-time flag, still supported |
 | `--config FILE`   | JSON config file from `recon`                                      |
 | `--interval SECONDS` | Poll interval in seconds (default: 30)                          |
 | `--max-duration MINUTES` | Stop after this many minutes (0 = unlimited)                |

--- a/docs/superpowers/plans/2026-04-17-launch-and-exact-targeting.md
+++ b/docs/superpowers/plans/2026-04-17-launch-and-exact-targeting.md
@@ -1,0 +1,625 @@
+# Launch And Exact Targeting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add compact date-list targeting, deterministic exact-time matching, and newly-released-only launch mode while preserving the existing broad window workflows.
+
+**Architecture:** Keep the current Playwright polling engine, but extend the data model so compact selectors can expand into concrete execution targets. Resolve launch-mode date deltas inside the runtime using a warmed browser session, then feed the resulting eligible dates into the same concurrent worker path the project already uses.
+
+**Tech Stack:** Python 3.9+, argparse, asyncio, Playwright async API, pytest, dataclasses
+
+---
+
+## File Structure
+
+- Modify: `models.py`
+  Add `Selector` and `LaunchConfig`, extend `Target` for exact-match mode, and teach `Task` how to expand selectors into concrete targets.
+- Modify: `main.py`
+  Parse new inline flags, build selector-based tasks, and keep legacy `--target` flows working.
+- Modify: `sniper.py`
+  Add exact-match semantics, launch-date delta resolution, and local-time default release handling.
+- Modify: `recon.py`
+  Emit selector-based fallback tasks for newly discovered dates and preserve save/load compatibility.
+- Modify: `README.md`
+  Document compact launch mode and local-time defaults.
+- Modify: `tests/test_models.py`
+  Cover selector parsing, launch config parsing, and target expansion.
+- Modify: `tests/test_sniper.py`
+  Cover exact-time matching, launch-date delta logic, and the async warning regression.
+- Modify: `tests/test_recon.py`
+  Cover selector-based task building and backward compatibility.
+
+### Task 1: Evolve The Data Model
+
+**Files:**
+- Modify: `models.py`
+- Test: `tests/test_models.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_selector_expands_dates_and_exact_times():
+    from models import Selector
+
+    selector = Selector(
+        dates=["2026-06-17", "2026-06-18"],
+        exact_times=["5:15 PM", "7:45 PM"],
+    )
+
+    targets = selector.expand_targets()
+
+    assert [(t.date, t.exact_time) for t in targets] == [
+        ("2026-06-17", "5:15 PM"),
+        ("2026-06-17", "7:45 PM"),
+        ("2026-06-18", "5:15 PM"),
+        ("2026-06-18", "7:45 PM"),
+    ]
+    assert all(t.earliest_time == t.latest_time for t in targets)
+
+
+def test_task_from_dict_accepts_selector_shape():
+    from models import Task
+
+    task = Task.from_dict({
+        "url": "taneda",
+        "size": "2",
+        "launch": {"release_at": "11:00", "newly_released_only": True},
+        "selectors": [
+            {
+                "dates": ["2026-06-17"],
+                "exact_times": ["5:15 PM", "7:45 PM"],
+            }
+        ],
+    })
+
+    assert task.launch is not None
+    assert task.launch.release_at == "11:00"
+    assert task.launch.newly_released_only is True
+    assert len(task.expand_targets()) == 2
+
+
+def test_task_from_dict_translates_legacy_targets():
+    from models import Task
+
+    task = Task.from_dict({
+        "url": "canlis",
+        "size": "2",
+        "targets": [
+            {
+                "date": "2026-03-15",
+                "earliest_time": "5:00 PM",
+                "latest_time": "9:30 PM",
+            }
+        ],
+    })
+
+    selector = task.selectors[0]
+    assert selector.dates == ["2026-03-15"]
+    assert selector.earliest_time == "5:00 PM"
+    assert selector.latest_time == "9:30 PM"
+```
+
+- [ ] **Step 2: Run the model tests to verify they fail**
+
+Run: `venv/bin/pytest tests/test_models.py -v`
+Expected: `ImportError` or `AttributeError` for missing `Selector`, missing `launch`, or missing `expand_targets`.
+
+- [ ] **Step 3: Write the minimal model implementation**
+
+```python
+@dataclass
+class LaunchConfig:
+    release_at: str
+    newly_released_only: bool = True
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "LaunchConfig":
+        return cls(
+            release_at=data["release_at"],
+            newly_released_only=data.get("newly_released_only", True),
+        )
+
+
+@dataclass
+class Selector:
+    dates: list[str]
+    earliest_time: str | None = None
+    latest_time: str | None = None
+    exact_times: list[str] = field(default_factory=list)
+
+    def expand_targets(self) -> list["Target"]:
+        if self.exact_times:
+            return [
+                Target(
+                    date=date,
+                    earliest_time=exact_time,
+                    latest_time=exact_time,
+                    exact_time=exact_time,
+                )
+                for date in self.dates
+                for exact_time in self.exact_times
+            ]
+
+        return [
+            Target(
+                date=date,
+                earliest_time=self.earliest_time or "12:00 PM",
+                latest_time=self.latest_time or "11:00 PM",
+            )
+            for date in self.dates
+        ]
+
+
+@dataclass
+class Target:
+    date: str
+    earliest_time: str
+    latest_time: str
+    exact_time: str | None = None
+
+
+@dataclass
+class Task:
+    url: str
+    size: str
+    selectors: list[Selector] = field(default_factory=list)
+    launch: LaunchConfig | None = None
+
+    def expand_targets(self) -> list[Target]:
+        targets: list[Target] = []
+        for selector in self.selectors:
+            targets.extend(selector.expand_targets())
+        return targets
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Task":
+        selectors_data = d.get("selectors")
+        if selectors_data is None:
+            selectors_data = [
+                {
+                    "dates": [target["date"]],
+                    "earliest_time": target["earliest_time"],
+                    "latest_time": target["latest_time"],
+                }
+                for target in d.get("targets", [])
+            ]
+        return cls(
+            url=d["url"],
+            size=d["size"],
+            selectors=[Selector(**s) for s in selectors_data],
+            launch=LaunchConfig.from_dict(d["launch"]) if d.get("launch") else None,
+        )
+```
+
+- [ ] **Step 4: Run the model tests to verify they pass**
+
+Run: `venv/bin/pytest tests/test_models.py -v`
+Expected: PASS for the new selector/launch tests and the existing URL/time tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add models.py tests/test_models.py
+git commit -m "feat: add selector-based task model"
+```
+
+### Task 2: Parse Compact CLI Inputs
+
+**Files:**
+- Modify: `main.py`
+- Test: `tests/test_models.py`
+
+- [ ] **Step 1: Write a failing helper test for inline selector construction**
+
+```python
+def test_task_inline_selector_defaults_to_any_time_when_exact_times_missing():
+    from models import Selector, Task
+
+    task = Task(
+        url="taneda",
+        size="2",
+        selectors=[Selector(dates=["2026-06-17"])],
+    )
+
+    targets = task.expand_targets()
+
+    assert len(targets) == 1
+    assert targets[0].date == "2026-06-17"
+    assert targets[0].earliest_time == "12:00 PM"
+    assert targets[0].latest_time == "11:00 PM"
+```
+
+- [ ] **Step 2: Run the targeted test to verify the broad fallback is not wired yet**
+
+Run: `venv/bin/pytest tests/test_models.py::test_task_inline_selector_defaults_to_any_time_when_exact_times_missing -v`
+Expected: FAIL if `Selector.expand_targets()` does not yet fall back to all-day broad targeting.
+
+- [ ] **Step 3: Add CLI helpers in `main.py`**
+
+```python
+def _build_inline_task(args: argparse.Namespace) -> Task:
+    if args.target:
+        selectors = [
+            Selector(
+                dates=[date],
+                earliest_time=earliest,
+                latest_time=latest,
+            )
+            for date, earliest, latest, _size in args.target
+        ]
+    else:
+        selectors = [
+            Selector(
+                dates=args.date or [],
+                exact_times=args.exact_time or [],
+            )
+        ]
+
+    launch = None
+    if getattr(args, "release_at", None):
+        launch = LaunchConfig(
+            release_at=args.release_at,
+            newly_released_only=getattr(args, "newly_released_only", False),
+        )
+
+    return Task(url=args.slug, size=args.size, selectors=selectors, launch=launch)
+```
+
+- [ ] **Step 4: Update parser arguments to expose the new flags**
+
+```python
+p_snipe.add_argument("--date", action="append", default=[], help="Target calendar date YYYY-MM-DD")
+p_snipe.add_argument("--exact-time", action="append", default=[], help="Exact reservation start time")
+p_snipe.add_argument("--newly-released-only", action="store_true",
+                     help="In launch mode, only target dates that appear after release")
+
+p_run.add_argument("--date", action="append", default=[], help="Target calendar date YYYY-MM-DD")
+p_run.add_argument("--exact-time", action="append", default=[], help="Exact reservation start time")
+p_run.add_argument("--newly-released-only", action="store_true",
+                   help="In launch mode, only target dates that appear after release")
+```
+
+- [ ] **Step 5: Wire `snipe` and `run` to use inline selectors when config is absent**
+
+```python
+elif args.target or args.date:
+    if not args.slug:
+        log.error("Inline targeting requires a restaurant slug.")
+        sys.exit(2)
+    tasks = [_build_inline_task(args)]
+```
+
+- [ ] **Step 6: Run the fast model and CLI-adjacent tests**
+
+Run: `venv/bin/pytest tests/test_models.py tests/test_recon.py -v`
+Expected: PASS, with no regressions in legacy target parsing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add main.py tests/test_models.py
+git commit -m "feat: add compact inline date and exact-time flags"
+```
+
+### Task 3: Implement Exact-Time Matching In The Worker
+
+**Files:**
+- Modify: `sniper.py`
+- Test: `tests/test_sniper.py`
+
+- [ ] **Step 1: Write the failing exact-match tests**
+
+```python
+@pytest.mark.asyncio
+async def test_exact_time_clicks_only_exact_match():
+    page = _make_page([
+        _make_slot_element("5:00 PM"),
+        _make_slot_element("5:15 PM"),
+        _make_slot_element("7:45 PM"),
+    ])
+    target = Target(
+        date="2026-06-17",
+        earliest_time="5:15 PM",
+        latest_time="5:15 PM",
+        exact_time="5:15 PM",
+    )
+    worker = _make_worker(target=target, page=page)
+
+    result = await worker._try_time()
+
+    assert result is True
+    page.query_selector_all.return_value[0].click.assert_not_awaited()
+    page.query_selector_all.return_value[1].click.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_parse_next_data_json_returns_none_for_non_dict():
+    from sniper import _parse_next_data_json
+    assert _parse_next_data_json(AsyncMock()) is None
+```
+
+- [ ] **Step 2: Run the targeted sniper tests to verify they fail**
+
+Run: `venv/bin/pytest tests/test_sniper.py::test_exact_time_clicks_only_exact_match tests/test_sniper.py::test_parse_next_data_json_returns_none_for_non_dict -v`
+Expected: FAIL because exact-time matching is not explicit and `_parse_next_data_json` still accepts non-dict values.
+
+- [ ] **Step 3: Add exact-match helpers to `Target` and `DayWorker`**
+
+```python
+def matches_time(self, time_text: str) -> bool:
+    if self.exact_time:
+        return time_text == self.exact_time
+
+    try:
+        candidate = datetime.strptime(time_text, RESERVATION_TIME_FORMAT)
+    except ValueError:
+        return False
+    return self.earliest_dt() <= candidate <= self.latest_dt()
+```
+
+```python
+def _any_slot_matches_target(self, time_strings: list[str]) -> bool:
+    return any(self.target.matches_time(time_text) for time_text in time_strings)
+```
+
+```python
+if not isinstance(next_data, dict):
+    return None
+```
+
+- [ ] **Step 4: Replace the broad-only checks inside `_poll()` and `_try_time()`**
+
+```python
+next_data_slots = await self._extract_next_data()
+if next_data_slots is not None and not self._any_slot_matches_target(next_data_slots):
+    return False
+
+...
+
+time_text = (await time_el.inner_text()).strip()
+if not self.target.matches_time(time_text):
+    continue
+```
+
+- [ ] **Step 5: Run the sniper unit suite**
+
+Run: `venv/bin/pytest tests/test_sniper.py -v`
+Expected: PASS, and the prior runtime warning disappears from the `test_day_worker_polls_immediately_first_iteration` path.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sniper.py tests/test_sniper.py
+git commit -m "feat: add deterministic exact-time slot matching"
+```
+
+### Task 4: Resolve Newly Released Dates In Launch Mode
+
+**Files:**
+- Modify: `sniper.py`
+- Test: `tests/test_sniper.py`
+
+- [ ] **Step 1: Write the failing launch-delta tests**
+
+```python
+def test_newly_released_dates_applies_delta_and_filter():
+    from sniper import _newly_released_dates
+
+    result = _newly_released_dates(
+        before={"2026-06-10", "2026-06-11"},
+        after={"2026-06-10", "2026-06-11", "2026-06-17", "2026-06-18"},
+        requested_dates=["2026-06-17", "2026-06-19"],
+    )
+
+    assert result == ["2026-06-17"]
+
+
+def test_task_filter_dates_preserves_exact_times():
+    selector = Selector(
+        dates=["2026-06-17", "2026-06-18"],
+        exact_times=["5:15 PM", "7:45 PM"],
+    )
+    task = Task(url="taneda", size="2", selectors=[selector])
+
+    filtered = task.filter_dates(["2026-06-18"])
+
+    assert [t.date for t in filtered.expand_targets()] == ["2026-06-18", "2026-06-18"]
+```
+
+- [ ] **Step 2: Run the targeted launch tests to verify they fail**
+
+Run: `venv/bin/pytest tests/test_sniper.py::test_newly_released_dates_applies_delta_and_filter tests/test_models.py::test_task_filter_dates_preserves_exact_times -v`
+Expected: FAIL for missing `_newly_released_dates` and missing `Task.filter_dates`.
+
+- [ ] **Step 3: Add date filtering helpers to the model**
+
+```python
+def filter_dates(self, eligible_dates: list[str]) -> "Task":
+    allowed = set(eligible_dates)
+    selectors = []
+    for selector in self.selectors:
+        kept_dates = [date for date in selector.dates if date in allowed]
+        if kept_dates:
+            selectors.append(Selector(
+                dates=kept_dates,
+                earliest_time=selector.earliest_time,
+                latest_time=selector.latest_time,
+                exact_times=list(selector.exact_times),
+            ))
+    return Task(url=self.url, size=self.size, selectors=selectors, launch=self.launch)
+```
+
+- [ ] **Step 4: Add launch-delta helpers to `sniper.py`**
+
+```python
+async def _capture_available_dates(page: Page, slug: str, size: str) -> set[str]:
+    url = f"https://www.exploretock.com/{slug}/search?date={datetime.now():%Y-%m}-01&size={size}&time=19%3A00"
+    await page.goto(url, wait_until="domcontentloaded", timeout=PAGE_LOAD_TIMEOUT)
+    await page.wait_for_selector("div.ConsumerCalendar-month", timeout=PAGE_LOAD_TIMEOUT)
+    await page.wait_for_timeout(2000)
+    buttons = await page.query_selector_all(
+        "button[data-testid='consumer-calendar-day'][aria-disabled='false']"
+    )
+    dates: set[str] = set()
+    for button in buttons:
+        label = await button.get_attribute("aria-label")
+        if label and len(label) == 10:
+            dates.add(label)
+    return dates
+
+
+def _newly_released_dates(before: set[str], after: set[str], requested_dates: list[str] | None = None) -> list[str]:
+    eligible = sorted(after - before)
+    if requested_dates:
+        requested = set(requested_dates)
+        eligible = [date for date in eligible if date in requested]
+    return eligible
+```
+
+- [ ] **Step 5: Move launch resolution into `snipe_task()` before worker creation**
+
+```python
+resolved_task = task
+if task.launch and task.launch.release_at and task.launch.newly_released_only:
+    scout = await context.new_page()
+    await _apply_stealth(scout)
+    before_dates = await _capture_available_dates(scout, task.url, task.size)
+    await _wait_for_release(task.launch.release_at)
+    after_dates = await _capture_available_dates(scout, task.url, task.size)
+    requested_dates = sorted({date for selector in task.selectors for date in selector.dates})
+    eligible_dates = _newly_released_dates(before_dates, after_dates, requested_dates)
+    if not eligible_dates:
+        await browser.close()
+        return None
+    resolved_task = task.filter_dates(eligible_dates)
+```
+
+- [ ] **Step 6: Build workers from `resolved_task.expand_targets()` instead of the old `task.targets`**
+
+```python
+expanded_targets = resolved_task.expand_targets()
+for i, target in enumerate(expanded_targets):
+    page = await context.new_page()
+    await _apply_stealth(page)
+    workers.append(
+        DayWorker(
+            resolved_task,
+            target,
+            page,
+            found_event,
+            dry_run=dry_run,
+            interval=interval,
+            prompt_login=prompt_login,
+        )
+    )
+```
+
+- [ ] **Step 7: Run the model and sniper tests together**
+
+Run: `venv/bin/pytest tests/test_models.py tests/test_sniper.py -v`
+Expected: PASS for launch delta logic, filtered selector expansion, and exact-time matching.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add models.py sniper.py tests/test_models.py tests/test_sniper.py
+git commit -m "feat: target only newly released launch dates"
+```
+
+### Task 5: Keep Recon And Docs In Sync
+
+**Files:**
+- Modify: `recon.py`
+- Modify: `README.md`
+- Test: `tests/test_recon.py`
+
+- [ ] **Step 1: Write the failing recon selector test**
+
+```python
+def test_build_tasks_uses_selector_shape():
+    avail = {
+        "2026-03-01": {"time_slots": ["5:00 PM", "9:00 PM"]},
+        "2026-03-15": {"time_slots": ["6:00 PM", "8:30 PM"]},
+    }
+
+    tasks = _build_tasks("taneda", "2", avail)
+
+    assert len(tasks) == 1
+    assert tasks[0].selectors[0].dates == ["2026-03-01", "2026-03-15"]
+    assert tasks[0].selectors[0].exact_times == []
+```
+
+- [ ] **Step 2: Run the recon test to verify it fails**
+
+Run: `venv/bin/pytest tests/test_recon.py::test_build_tasks_uses_selector_shape -v`
+Expected: FAIL because `_build_tasks()` still emits only legacy `Target` entries.
+
+- [ ] **Step 3: Update `_build_tasks()` to emit selector-based tasks**
+
+```python
+def _build_tasks(slug: str, size: str, availability: Dict[str, dict]) -> List[Task]:
+    if not availability:
+        return []
+
+    selectors: list[Selector] = []
+    for date_str, data in availability.items():
+        slots = [_parse_time(t) for t in data.get("time_slots", []) if _parse_time(t)]
+        if slots:
+            selectors.append(Selector(
+                dates=[date_str],
+                earliest_time=_time_str(min(slots)),
+                latest_time=_time_str(max(slots)),
+            ))
+        else:
+            selectors.append(Selector(dates=[date_str]))
+
+    return [Task(url=slug, size=size, selectors=selectors)]
+```
+
+- [ ] **Step 4: Update README examples for compact launch mode**
+
+```md
+python main.py run taneda \
+  --size 2 \
+  --release-at 11:00 \
+  --newly-released-only \
+  --date 2026-06-17 \
+  --date 2026-06-18 \
+  --exact-time "5:15 PM" \
+  --exact-time "7:45 PM"
+```
+
+```md
+`--release-at` uses the local machine time by default.
+```
+
+- [ ] **Step 5: Run the full fast test suite**
+
+Run: `venv/bin/pytest tests/ --ignore=tests/integration -v`
+Expected: PASS with all unit tests green.
+
+- [ ] **Step 6: Run the live smoke test**
+
+Run: `PLAYWRIGHT_HEADLESS=1 venv/bin/pytest tests/integration/test_smoke.py -q -s`
+Expected: PASS with calendar render confirmation on a live Tock page.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add recon.py README.md tests/test_recon.py
+git commit -m "docs: add compact launch-mode targeting examples"
+```
+
+## Self-Review
+
+- Spec coverage:
+  - compact date lists are implemented in Task 1 and Task 2
+  - exact-time deterministic matching is implemented in Task 1 and Task 3
+  - newly released date targeting is implemented in Task 4
+  - local-time `release_at` behavior is preserved and documented in Task 4 and Task 5
+  - backward compatibility for legacy target configs is covered in Task 1 and Task 5
+- Placeholder scan:
+  - no `TODO`, `TBD`, or “implement later” markers remain
+  - each code-changing step includes concrete code blocks
+- Type consistency:
+  - `LaunchConfig`, `Selector`, `Task.expand_targets()`, `Task.filter_dates()`, `_newly_released_dates()`, and `Target.exact_time` are used consistently across tasks

--- a/docs/superpowers/specs/2026-04-17-launch-and-exact-targeting-design.md
+++ b/docs/superpowers/specs/2026-04-17-launch-and-exact-targeting-design.md
@@ -1,0 +1,236 @@
+# Launch And Exact Targeting Design
+
+## Context
+
+`T0ckSn1per` already supports:
+
+- `recon` to discover currently visible dates
+- `snipe` to poll for any slot inside a configured time window
+- `run` to combine recon and sniping with an optional `--release-at`
+
+For Taneda-style drops, the current model is too loose. The user knows the reservation start times in advance and wants the bot to act deterministically at release, rather than scanning broad time windows or targeting already-visible dates.
+
+## Goals
+
+- Support a compact way to target a list of dates without requiring the user to enumerate every date/time pair manually
+- Support deterministic exact-time attacks such as `5:15 PM` and `7:45 PM`
+- Keep existing broad window matching for users who do not know exact times
+- Make launch mode operate only on newly released dates, not inventory that was already visible before the drop
+- Interpret `release_at` in local machine time by default
+
+## Non-Goals
+
+- Replacing the existing `recon` or broad polling flows
+- Requiring the user to think about timezone names for normal local runs
+- Automatically inferring restaurant-specific release rules from the network or site
+
+## User-Facing Model
+
+The system supports two independent axes:
+
+- Launch mode:
+  Wait until a configured release time, then target only newly released dates.
+- Exact mode:
+  Attempt only exact reservation start times, rather than matching any slot within a time range.
+
+These do not conflict. A run can be:
+
+- Broad restock mode: no launch mode, no exact times
+- Broad launch mode: launch mode enabled, no exact times
+- Deterministic launch mode: launch mode enabled, exact times supplied
+- Deterministic non-launch mode: exact times supplied without launch mode
+
+## Config Shape
+
+The task schema should evolve from only `targets` with one date and one broad range per entry to a more compact selector-oriented model.
+
+Recommended shape:
+
+```json
+[
+  {
+    "url": "taneda",
+    "size": "2",
+    "launch": {
+      "release_at": "11:00",
+      "newly_released_only": true
+    },
+    "selectors": [
+      {
+        "dates": ["2026-06-17", "2026-06-18"],
+        "exact_times": ["5:15 PM", "7:45 PM"]
+      }
+    ]
+  }
+]
+```
+
+Behavior:
+
+- `dates` is a list of acceptable calendar dates
+- `exact_times` is optional
+- if `exact_times` is present, matching is deterministic and exact
+- if `exact_times` is omitted, the bot accepts any slot that matches the date selector
+- `launch.release_at` is optional; when present, the bot enters launch mode
+- `launch.newly_released_only` defaults to `true` when launch mode is used
+
+## CLI Shape
+
+The CLI should support both config-driven and inline usage.
+
+Recommended inline flags:
+
+- `--date YYYY-MM-DD`
+  Repeatable. Adds an acceptable target date.
+- `--exact-time "H:MM AM/PM"`
+  Repeatable. Enables exact-match mode.
+- `--release-at HH:MM`
+  Uses local machine time by default.
+- `--newly-released-only`
+  Enabled explicitly in CLI. For launch mode, this is the normal path.
+
+Example:
+
+```bash
+python main.py run taneda \
+  --size 2 \
+  --release-at 11:00 \
+  --newly-released-only \
+  --date 2026-06-17 \
+  --date 2026-06-18 \
+  --exact-time "5:15 PM" \
+  --exact-time "7:45 PM"
+```
+
+This means:
+
+- wait until `11:00` in local machine time
+- determine which dates are newly released at that moment
+- narrow to the user-provided date list if one was supplied
+- try exact start times `5:15 PM` and `7:45 PM` concurrently on any remaining target dates
+
+## Local Time Default
+
+`release_at` should use the local machine timezone by default.
+
+User experience:
+
+- if the user says `11:00`, it means `11:00` on the machine that runs the bot
+- timezone names should not be required for normal usage
+
+Implementation guidance:
+
+- keep optional timezone override support only as an advanced/internal capability if needed
+- do not make timezone selection part of the primary UX
+
+## Runtime Semantics
+
+### Broad Matching
+
+If no `exact_times` are supplied:
+
+- the bot may use any slot that appears on the allowed date set
+- in non-launch mode, this behaves like the current date-plus-window behavior, though selectors may be broader
+- in launch mode, it must still limit itself to newly released dates only
+
+### Exact Matching
+
+If `exact_times` are supplied:
+
+- the bot must not scan a broad time range first
+- it should attempt only the listed exact start times
+- exact-time attempts should run concurrently
+- the first successful cart add wins and stops the rest
+
+### Launch Mode
+
+When `release_at` is present:
+
+1. Open and warm the browser session before release time
+2. Capture the set of currently visible dates before the release
+3. At the release moment, refresh or re-fetch availability
+4. Compute the difference between post-release visible dates and pre-release visible dates
+5. Treat only that delta as the eligible date set
+6. If the user supplied a date list, intersect it with the newly released date set
+7. Execute broad or exact matching against the resulting dates
+
+This prevents the bot from wasting effort on already-visible inventory during a timed launch.
+
+## Data Model Evolution
+
+The current `Target` model represents one date with one time window. That shape should evolve to support compact user intent.
+
+Recommended direction:
+
+- add a higher-level selector model that can represent:
+  - multiple dates
+  - optional exact times
+  - optional broad window fallback
+- keep backward compatibility by translating old target entries into the new internal selector form
+
+Backward compatibility examples:
+
+- Existing target:
+  - one date
+  - `earliest_time`
+  - `latest_time`
+- New selector:
+  - many dates
+  - optional `exact_times`
+  - optional broad matching fields if exact times are absent
+
+## Execution Strategy
+
+Internally, the runtime can still expand compact user input into concrete worker attempts.
+
+Examples:
+
+- `dates = [d1, d2]` and `exact_times = [t1, t2]`
+  expands to four exact attempts:
+  - `d1 x t1`
+  - `d1 x t2`
+  - `d2 x t1`
+  - `d2 x t2`
+- `dates = [d1, d2]` and no `exact_times`
+  expands to two date-level broad workers:
+  - `d1`
+  - `d2`
+
+This keeps the input compact while preserving concurrency in the execution layer.
+
+## Error Handling
+
+- If launch mode produces no newly released dates, exit cleanly with a no-slots result
+- If launch mode plus user date filters leaves no eligible dates, exit cleanly with a no-slots result
+- If exact times are supplied but none of them appear for the eligible dates, continue polling according to launch/restock semantics until success or timeout
+- If both old broad-window fields and `exact_times` are supplied for the same selector, exact-time semantics should take precedence and the configuration should warn clearly in logs
+
+## Testing
+
+Required coverage:
+
+- unit tests for config parsing of selectors, dates, and exact times
+- unit tests for backward compatibility with existing target-based configs
+- unit tests for exact-match filtering behavior
+- unit tests for launch-mode delta computation between pre-release and post-release date sets
+- unit tests for intersection of newly released dates with user-supplied date filters
+- integration coverage that exercises launch-mode date-set computation without risking real slot checkout
+
+## Rollout
+
+Implementation should preserve current workflows while adding the new compact targeting path.
+
+The first ship target is battle readiness for Taneda-style drops:
+
+- local-time `release_at`
+- newly released dates only
+- exact start times such as `5:15 PM` and `7:45 PM`
+- compact date list input
+
+## Open Decisions Resolved
+
+- Launch mode and exact mode are independent axes and can be combined
+- The system should accept a list of dates, not force one entry per date/time pair
+- If the user does not provide exact times, the bot should accept any slot on the eligible date set
+- In launch mode, the eligible date set is only the newly released dates
+- `release_at` uses local machine time by default

--- a/main.py
+++ b/main.py
@@ -74,25 +74,40 @@ def _print_results(results: list, json_mode: bool) -> None:
         sys.exit(1)
 
 
+def _split_csv_values(raw: str) -> list[str]:
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+
+def _collect_inline_values(args: argparse.Namespace, singular_name: str, plural_name: str) -> list[str]:
+    values = list(getattr(args, singular_name, []) or [])
+    plural_value = getattr(args, plural_name, None)
+    if plural_value:
+        values.extend(_split_csv_values(plural_value))
+    return values
+
+
 def _build_inline_task(args: argparse.Namespace) -> Task:
-    if args.target:
+    target_args = getattr(args, "target", None)
+    if target_args:
         selectors = [
             Selector(
                 dates=[date],
                 earliest_time=earliest,
                 latest_time=latest,
             )
-            for date, earliest, latest, _size in args.target
+            for date, earliest, latest, _size in target_args
         ]
-        size = args.target[0][3]
+        size = target_args[0][3]
     else:
+        dates = _collect_inline_values(args, "date", "dates")
+        exact_times = _collect_inline_values(args, "exact_time", "exact_times")
         selectors = [
             Selector(
-                dates=list(getattr(args, "date", []) or []),
-                exact_times=list(getattr(args, "exact_time", []) or []),
+                dates=dates,
+                exact_times=exact_times,
             )
         ]
-        size = args.size
+        size = getattr(args, "size", "2")
 
     launch = None
     if getattr(args, "release_at", None):
@@ -121,13 +136,13 @@ async def _cmd_recon(args: argparse.Namespace) -> None:
 async def _cmd_snipe(args: argparse.Namespace) -> None:
     if args.config:
         tasks = load_config(args.config)
-    elif args.target or args.date:
+    elif args.target or args.date or getattr(args, "dates", None):
         if not args.slug:
             log.error("Inline targeting requires a restaurant slug as positional argument")
             sys.exit(2)
         tasks = [_build_inline_task(args)]
     else:
-        log.error("Provide --config FILE, --target ..., or at least one --date")
+        log.error("Provide --config FILE, --target ..., or at least one --date/--dates")
         sys.exit(2)
 
     if not tasks:
@@ -149,7 +164,7 @@ async def _cmd_snipe(args: argparse.Namespace) -> None:
 
 
 async def _cmd_run(args: argparse.Namespace) -> None:
-    if args.date or args.exact_time:
+    if args.date or args.exact_time or getattr(args, "dates", None) or getattr(args, "exact_times", None):
         tasks = [_build_inline_task(args)]
     else:
         tasks = await recon(args.slug, size=args.size)
@@ -203,6 +218,10 @@ def _build_parser() -> argparse.ArgumentParser:
                          help="Target calendar date YYYY-MM-DD (repeatable)")
     p_snipe.add_argument("--exact-time", action="append", default=[],
                          help="Exact reservation start time, e.g. '5:15 PM' (repeatable)")
+    p_snipe.add_argument("--dates",
+                         help="Comma-separated target dates, e.g. '2026-05-27,2026-05-28'")
+    p_snipe.add_argument("--exact-times",
+                         help="Comma-separated exact times, e.g. '5:15 PM,7:45 PM'")
     p_snipe.add_argument("--dry-run", action="store_true", help="Find slots but don't click")
     p_snipe.add_argument("--interval", type=float, default=30.0, metavar="SECONDS",
                          help="Poll interval in seconds (default: 30)")
@@ -231,6 +250,10 @@ def _build_parser() -> argparse.ArgumentParser:
                        help="Target calendar date YYYY-MM-DD (repeatable)")
     p_run.add_argument("--exact-time", action="append", default=[],
                        help="Exact reservation start time, e.g. '5:15 PM' (repeatable)")
+    p_run.add_argument("--dates",
+                       help="Comma-separated target dates, e.g. '2026-05-27,2026-05-28'")
+    p_run.add_argument("--exact-times",
+                       help="Comma-separated exact times, e.g. '5:15 PM,7:45 PM'")
     p_run.add_argument("--dry-run", action="store_true", help="Find slots but don't click")
     p_run.add_argument("--save", metavar="FILE", help="Also save recon config to JSON")
     p_run.add_argument("--interval", type=float, default=30.0, metavar="SECONDS",

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ import json
 import logging
 import sys
 
-from models import Task, Target
+from models import LaunchConfig, Selector, Task, Target
 from recon import recon, save_config, load_config
 from sniper import snipe_all
 
@@ -74,6 +74,36 @@ def _print_results(results: list, json_mode: bool) -> None:
         sys.exit(1)
 
 
+def _build_inline_task(args: argparse.Namespace) -> Task:
+    if args.target:
+        selectors = [
+            Selector(
+                dates=[date],
+                earliest_time=earliest,
+                latest_time=latest,
+            )
+            for date, earliest, latest, _size in args.target
+        ]
+        size = args.target[0][3]
+    else:
+        selectors = [
+            Selector(
+                dates=list(getattr(args, "date", []) or []),
+                exact_times=list(getattr(args, "exact_time", []) or []),
+            )
+        ]
+        size = args.size
+
+    launch = None
+    if getattr(args, "release_at", None):
+        launch = LaunchConfig(
+            release_at=args.release_at,
+            newly_released_only=getattr(args, "newly_released_only", False),
+        )
+
+    return Task(url=args.slug, size=size, selectors=selectors, launch=launch)
+
+
 # ── Subcommand handlers ───────────────────────────────────────────────────────
 
 async def _cmd_recon(args: argparse.Namespace) -> None:
@@ -91,17 +121,13 @@ async def _cmd_recon(args: argparse.Namespace) -> None:
 async def _cmd_snipe(args: argparse.Namespace) -> None:
     if args.config:
         tasks = load_config(args.config)
-    elif args.target:
+    elif args.target or args.date:
         if not args.slug:
-            log.error("--target requires a restaurant slug as positional argument")
+            log.error("Inline targeting requires a restaurant slug as positional argument")
             sys.exit(2)
-        targets = [
-            Target(date=t[0], earliest_time=t[1], latest_time=t[2])
-            for t in args.target
-        ]
-        tasks = [Task(url=args.slug, size=args.target[0][3], targets=targets)]
+        tasks = [_build_inline_task(args)]
     else:
-        log.error("Provide --config FILE or --target DATE EARLIEST LATEST SIZE")
+        log.error("Provide --config FILE, --target ..., or at least one --date")
         sys.exit(2)
 
     if not tasks:
@@ -123,12 +149,15 @@ async def _cmd_snipe(args: argparse.Namespace) -> None:
 
 
 async def _cmd_run(args: argparse.Namespace) -> None:
-    tasks = await recon(args.slug, size=args.size)
-    if not tasks:
-        log.warning("Recon found no availability for '%s'. Nothing to snipe.", args.slug)
-        sys.exit(1)
-    if args.save:
-        save_config(tasks, args.save)
+    if args.date or args.exact_time:
+        tasks = [_build_inline_task(args)]
+    else:
+        tasks = await recon(args.slug, size=args.size)
+        if not tasks:
+            log.warning("Recon found no availability for '%s'. Nothing to snipe.", args.slug)
+            sys.exit(1)
+        if args.save:
+            save_config(tasks, args.save)
     snipe_kwargs = dict(
         dry_run=args.dry_run,
         interval=args.interval,
@@ -161,7 +190,7 @@ def _build_parser() -> argparse.ArgumentParser:
     # snipe
     p_snipe = sub.add_parser("snipe", help="Snipe using a config file or inline targets")
     p_snipe.add_argument("slug", nargs="?", default=None,
-                         help="Tock restaurant slug (required when using --target)")
+                         help="Tock restaurant slug (required for inline targeting)")
     p_snipe.add_argument("--config", metavar="FILE", help="JSON config from recon")
     p_snipe.add_argument(
         "--target",
@@ -170,6 +199,10 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar=("DATE", "EARLIEST", "LATEST", "SIZE"),
         help="Inline target: DATE EARLIEST LATEST SIZE (repeatable)",
     )
+    p_snipe.add_argument("--date", action="append", default=[],
+                         help="Target calendar date YYYY-MM-DD (repeatable)")
+    p_snipe.add_argument("--exact-time", action="append", default=[],
+                         help="Exact reservation start time, e.g. '5:15 PM' (repeatable)")
     p_snipe.add_argument("--dry-run", action="store_true", help="Find slots but don't click")
     p_snipe.add_argument("--interval", type=float, default=30.0, metavar="SECONDS",
                          help="Poll interval in seconds (default: 30)")
@@ -177,6 +210,8 @@ def _build_parser() -> argparse.ArgumentParser:
                          help="Stop after this many minutes (0 = unlimited)")
     p_snipe.add_argument("--release-at", metavar="HH:MM",
                          help="Start sniping at this time of day")
+    p_snipe.add_argument("--newly-released-only", action="store_true",
+                         help="In launch mode, only target dates that appear after release")
     p_snipe.add_argument("--timezone", metavar="TZ",
                          help="Timezone for --release-at (e.g. America/Chicago)")
     p_snipe.add_argument("--cookies-file", metavar="FILE",
@@ -192,6 +227,10 @@ def _build_parser() -> argparse.ArgumentParser:
     p_run = sub.add_parser("run", help="Recon then snipe in one shot")
     p_run.add_argument("slug", help="Tock restaurant slug, e.g. 'canlis'")
     p_run.add_argument("--size", default="2", help="Party size (default: 2)")
+    p_run.add_argument("--date", action="append", default=[],
+                       help="Target calendar date YYYY-MM-DD (repeatable)")
+    p_run.add_argument("--exact-time", action="append", default=[],
+                       help="Exact reservation start time, e.g. '5:15 PM' (repeatable)")
     p_run.add_argument("--dry-run", action="store_true", help="Find slots but don't click")
     p_run.add_argument("--save", metavar="FILE", help="Also save recon config to JSON")
     p_run.add_argument("--interval", type=float, default=30.0, metavar="SECONDS",
@@ -200,6 +239,8 @@ def _build_parser() -> argparse.ArgumentParser:
                        help="Stop after this many minutes (0 = unlimited)")
     p_run.add_argument("--release-at", metavar="HH:MM",
                        help="Start sniping at this time of day")
+    p_run.add_argument("--newly-released-only", action="store_true",
+                       help="In launch mode, only target dates that appear after release")
     p_run.add_argument("--timezone", metavar="TZ",
                        help="Timezone for --release-at (e.g. America/Chicago)")
     p_run.add_argument("--cookies-file", metavar="FILE",

--- a/models.py
+++ b/models.py
@@ -3,31 +3,60 @@
 import json
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import List, Optional
 
 RESERVATION_TIME_FORMAT = "%I:%M %p"
 
 
 @dataclass
+class LaunchConfig:
+    """Launch-mode settings for timed drops."""
+
+    release_at: str
+    newly_released_only: bool = True
+
+    def to_dict(self) -> dict:
+        return {
+            "release_at": self.release_at,
+            "newly_released_only": self.newly_released_only,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "LaunchConfig":
+        return cls(
+            release_at=data["release_at"],
+            newly_released_only=data.get("newly_released_only", True),
+        )
+
+
+@dataclass
 class Target:
     """
-    A single date/time window to watch for a reservation.
+    A concrete date/time attempt to watch for a reservation.
 
-    Fields
-    ------
-    date          : ISO date string, e.g. "2026-03-15"
-    earliest_time : Lower bound of acceptable window, e.g. "5:00 PM"
-    latest_time   : Upper bound of acceptable window, e.g. "9:30 PM"
+    In exact mode, earliest_time == latest_time and exact_time is populated.
     """
 
-    date:           str
-    earliest_time:  str
-    latest_time:    str
+    date: str
+    earliest_time: str
+    latest_time: str
+    exact_time: Optional[str] = None
 
     def earliest_dt(self) -> datetime:
         return datetime.strptime(self.earliest_time, RESERVATION_TIME_FORMAT)
 
     def latest_dt(self) -> datetime:
         return datetime.strptime(self.latest_time, RESERVATION_TIME_FORMAT)
+
+    def matches_time(self, time_text: str) -> bool:
+        if self.exact_time is not None:
+            return time_text == self.exact_time
+
+        try:
+            candidate = datetime.strptime(time_text, RESERVATION_TIME_FORMAT)
+        except ValueError:
+            return False
+        return self.earliest_dt() <= candidate <= self.latest_dt()
 
     def search_url(self, restaurant_slug: str, party_size: str) -> str:
         # Derive time param from midpoint of the target window so Tock's
@@ -46,15 +75,77 @@ class Target:
         )
 
     def to_dict(self) -> dict:
-        return {
-            "date":           self.date,
-            "earliest_time":  self.earliest_time,
-            "latest_time":    self.latest_time,
+        data = {
+            "date": self.date,
+            "earliest_time": self.earliest_time,
+            "latest_time": self.latest_time,
         }
+        if self.exact_time:
+            data["exact_time"] = self.exact_time
+        return data
 
     @classmethod
     def from_dict(cls, d: dict) -> "Target":
-        return cls(**d)
+        return cls(
+            date=d["date"],
+            earliest_time=d["earliest_time"],
+            latest_time=d["latest_time"],
+            exact_time=d.get("exact_time"),
+        )
+
+
+@dataclass
+class Selector:
+    """Compact user intent that can expand into one or more concrete targets."""
+
+    dates: List[str]
+    earliest_time: Optional[str] = None
+    latest_time: Optional[str] = None
+    exact_times: List[str] = field(default_factory=list)
+
+    def expand_targets(self) -> List[Target]:
+        if self.exact_times:
+            return [
+                Target(
+                    date=date,
+                    earliest_time=exact_time,
+                    latest_time=exact_time,
+                    exact_time=exact_time,
+                )
+                for date in self.dates
+                for exact_time in self.exact_times
+            ]
+
+        earliest_time = self.earliest_time or "12:00 PM"
+        latest_time = self.latest_time or "11:00 PM"
+        return [
+            Target(
+                date=date,
+                earliest_time=earliest_time,
+                latest_time=latest_time,
+            )
+            for date in self.dates
+        ]
+
+    def to_dict(self) -> dict:
+        data = {"dates": list(self.dates)}
+        if self.exact_times:
+            data["exact_times"] = list(self.exact_times)
+        else:
+            if self.earliest_time is not None:
+                data["earliest_time"] = self.earliest_time
+            if self.latest_time is not None:
+                data["latest_time"] = self.latest_time
+        return data
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Selector":
+        return cls(
+            dates=list(d.get("dates", [])),
+            earliest_time=d.get("earliest_time"),
+            latest_time=d.get("latest_time"),
+            exact_times=list(d.get("exact_times", [])),
+        )
 
 
 @dataclass
@@ -62,28 +153,87 @@ class Task:
     """
     A restaurant reservation sniper task.
 
-    Fields
-    ------
-    url     : Tock restaurant slug, e.g. "alinea"
-    size    : Party size as a string, e.g. "2"
-    targets : List of Target objects specifying date/time windows to watch
+    `selectors` is the canonical representation. `targets` remains available as
+    a computed compatibility property for the existing worker code.
     """
 
-    url:     str
-    size:    str
-    targets: list[Target] = field(default_factory=list)
+    url: str
+    size: str
+    selectors: List[Selector] = field(default_factory=list)
+    launch: Optional[LaunchConfig] = None
+
+    @property
+    def targets(self) -> List[Target]:
+        return self.expand_targets()
+
+    def expand_targets(self) -> List[Target]:
+        targets: List[Target] = []
+        for selector in self.selectors:
+            targets.extend(selector.expand_targets())
+        return targets
+
+    def filter_dates(self, eligible_dates: List[str]) -> "Task":
+        allowed = set(eligible_dates)
+        selectors: List[Selector] = []
+        for selector in self.selectors:
+            source_dates = selector.dates or list(eligible_dates)
+            kept_dates = [date for date in source_dates if date in allowed]
+            if kept_dates:
+                selectors.append(Selector(
+                    dates=kept_dates,
+                    earliest_time=selector.earliest_time,
+                    latest_time=selector.latest_time,
+                    exact_times=list(selector.exact_times),
+                ))
+        return Task(url=self.url, size=self.size, selectors=selectors, launch=self.launch)
 
     def to_dict(self) -> dict:
-        return {
-            "url":     self.url,
-            "size":    self.size,
-            "targets": [t.to_dict() for t in self.targets],
+        data = {
+            "url": self.url,
+            "size": self.size,
         }
+
+        if self.launch is not None:
+            data["launch"] = self.launch.to_dict()
+
+        can_emit_legacy_targets = (
+            self.launch is None and
+            all(len(selector.dates) == 1 and not selector.exact_times for selector in self.selectors)
+        )
+
+        if can_emit_legacy_targets:
+            data["targets"] = [
+                {
+                    "date": selector.dates[0],
+                    "earliest_time": selector.earliest_time or "12:00 PM",
+                    "latest_time": selector.latest_time or "11:00 PM",
+                }
+                for selector in self.selectors
+            ]
+        else:
+            data["selectors"] = [selector.to_dict() for selector in self.selectors]
+
+        return data
 
     @classmethod
     def from_dict(cls, d: dict) -> "Task":
-        targets = [Target.from_dict(t) for t in d.get("targets", [])]
-        return cls(url=d["url"], size=d["size"], targets=targets)
+        selectors_data = d.get("selectors")
+        if selectors_data is None:
+            selectors_data = [
+                {
+                    "dates": [target["date"]],
+                    "earliest_time": target["earliest_time"],
+                    "latest_time": target["latest_time"],
+                }
+                for target in d.get("targets", [])
+            ]
+
+        return cls(
+            url=d["url"],
+            size=d["size"],
+            selectors=[Selector.from_dict(selector) for selector in selectors_data],
+            launch=LaunchConfig.from_dict(d["launch"]) if d.get("launch") else None,
+        )
 
     def __repr__(self) -> str:
         return json.dumps(self.to_dict(), indent=2)

--- a/recon.py
+++ b/recon.py
@@ -23,7 +23,7 @@ from typing import Dict, List, Optional, Tuple
 
 from playwright.async_api import async_playwright, Browser, BrowserContext, Page, TimeoutError as PWTimeout
 
-from models import Task, Target, RESERVATION_TIME_FORMAT
+from models import Selector, Task, RESERVATION_TIME_FORMAT
 from sniper import _parse_next_data_json, NEXT_DATA_JS
 
 log = logging.getLogger(__name__)
@@ -189,7 +189,7 @@ def _build_tasks(slug: str, size: str, availability: Dict[str, dict]) -> List[Ta
     if not availability:
         return []
 
-    targets: List[Target] = []
+    selectors: List[Selector] = []
     for date_str, data in availability.items():
         slots = [_parse_time(t) for t in data.get("time_slots", []) if _parse_time(t)]
         if slots:
@@ -204,16 +204,16 @@ def _build_tasks(slug: str, size: str, availability: Dict[str, dict]) -> List[Ta
             earliest_time = "12:00 PM"
             latest_time   = "11:00 PM"
 
-        targets.append(Target(
-            date=date_str,
+        selectors.append(Selector(
+            dates=[date_str],
             earliest_time=earliest_time,
             latest_time=latest_time,
         ))
 
-    if not targets:
+    if not selectors:
         return []
 
-    return [Task(url=slug, size=size, targets=targets)]
+    return [Task(url=slug, size=size, selectors=selectors)]
 
 
 # ── Optional Claude enhancement ───────────────────────────────────────────────

--- a/sniper.py
+++ b/sniper.py
@@ -140,7 +140,7 @@ def _parse_next_data_json(next_data: dict) -> Optional[list]:
     Returns a list of "H:MM AM/PM" time strings, or None if no availability
     data could be extracted.
     """
-    if not next_data:
+    if not next_data or not isinstance(next_data, dict):
         return None
 
     try:
@@ -192,6 +192,26 @@ def _parse_next_data_json(next_data: dict) -> Optional[list]:
             seen.add(t)
             result.append(t)
     return result
+
+
+def _requested_dates_from_task(task: Task) -> Optional[list]:
+    requested = []
+    for selector in task.selectors:
+        requested.extend(selector.dates)
+    unique = sorted(set(requested))
+    return unique or None
+
+
+def _newly_released_dates(
+    before: set,
+    after: set,
+    requested_dates: Optional[list] = None,
+) -> list:
+    eligible = sorted(after - before)
+    if requested_dates:
+        allowed = set(requested_dates)
+        eligible = [date for date in eligible if date in allowed]
+    return eligible
 
 
 # ── Stealth helper ────────────────────────────────────────────────────────────
@@ -275,12 +295,8 @@ class DayWorker:
     def _any_slot_in_window(self, time_strings: list) -> bool:
         """Check if any time string falls within the target's earliest/latest window."""
         for t_str in time_strings:
-            try:
-                t = datetime.strptime(t_str, RESERVATION_TIME_FORMAT)
-                if self.target.earliest_dt() <= t <= self.target.latest_dt():
-                    return True
-            except ValueError:
-                continue
+            if self.target.matches_time(t_str):
+                return True
         return False
 
     async def _poll(self) -> bool:
@@ -365,46 +381,43 @@ class DayWorker:
                 if not time_el:
                     continue
                 time_text = (await time_el.inner_text()).strip()
-                try:
-                    t = datetime.strptime(time_text, RESERVATION_TIME_FORMAT)
-                except ValueError:
+                if not self.target.matches_time(time_text):
                     continue
-                if self.target.earliest_dt() <= t <= self.target.latest_dt():
-                    book_btn = await card.query_selector(
-                        "button[data-testid='booking-card-button']"
-                    )
-                    if not book_btn:
-                        continue
-                    log.info("[%s/%s] Clicking slot %s", self.task.url, self.target.date, time_text)
-                    self.matched_time = time_text
-                    if not self.dry_run:
-                        await book_btn.click()
-                        cart_confirmed = False
-                        try:
-                            await self.page.wait_for_url("**/checkout/**", timeout=8000)
+                book_btn = await card.query_selector(
+                    "button[data-testid='booking-card-button']"
+                )
+                if not book_btn:
+                    continue
+                log.info("[%s/%s] Clicking slot %s", self.task.url, self.target.date, time_text)
+                self.matched_time = time_text
+                if not self.dry_run:
+                    await book_btn.click()
+                    cart_confirmed = False
+                    try:
+                        await self.page.wait_for_url("**/checkout/**", timeout=8000)
+                        cart_confirmed = True
+                    except PWTimeout:
+                        # Fallback checks per PRD FR-8
+                        holding = await self.page.query_selector("[data-testid='holding-time']")
+                        if holding:
                             cart_confirmed = True
-                        except PWTimeout:
-                            # Fallback checks per PRD FR-8
-                            holding = await self.page.query_selector("[data-testid='holding-time']")
-                            if holding:
-                                cart_confirmed = True
-                            else:
-                                complete_el = await self.page.query_selector("text='Complete your reservation'")
-                                if complete_el:
-                                    cart_confirmed = True
-
-                        if cart_confirmed:
-                            self.checkout_url = self.page.url
-                            return True
                         else:
-                            log.warning(
-                                "[%s/%s] Clicked slot %s but cart add not confirmed — retrying next cycle",
-                                self.task.url, self.target.date, time_text,
-                            )
-                            return False
-                    else:
-                        self.checkout_url = "(dry-run)"
+                            complete_el = await self.page.query_selector("text='Complete your reservation'")
+                            if complete_el:
+                                cart_confirmed = True
+
+                    if cart_confirmed:
+                        self.checkout_url = self.page.url
                         return True
+                    else:
+                        log.warning(
+                            "[%s/%s] Clicked slot %s but cart add not confirmed — retrying next cycle",
+                            self.task.url, self.target.date, time_text,
+                        )
+                        return False
+                else:
+                    self.checkout_url = "(dry-run)"
+                    return True
         except PWTimeout:
             log.debug("[%s/%s] No search-result cards loaded", self.task.url, self.target.date)
         except Exception as e:
@@ -564,6 +577,30 @@ async def _wait_for_release(release_at: str, timezone: str = None) -> None:
     log.info("RELEASE TIME %s — firing all workers!", release_at)
 
 
+async def _capture_available_dates(page: Page, slug: str, size: str) -> set:
+    """Capture currently visible available dates from the restaurant calendar."""
+    month_n = f"{datetime.now().month:02d}"
+    year = str(datetime.now().year)
+    url = (
+        f"https://www.exploretock.com/{slug}/search"
+        f"?date={year}-{month_n}-01&size={size}&time=19%3A00"
+    )
+
+    await page.goto(url, wait_until="domcontentloaded", timeout=PAGE_LOAD_TIMEOUT)
+    await page.wait_for_selector("div.ConsumerCalendar-month", timeout=PAGE_LOAD_TIMEOUT)
+    await page.wait_for_timeout(2000)
+
+    buttons = await page.query_selector_all(
+        "button[data-testid='consumer-calendar-day'][aria-disabled='false']"
+    )
+    dates = set()
+    for button in buttons:
+        label = await button.get_attribute("aria-label")
+        if label and len(label) == 10:
+            dates.add(label)
+    return dates
+
+
 # ── Task orchestration ────────────────────────────────────────────────────────
 
 async def snipe_task(
@@ -582,6 +619,8 @@ async def snipe_task(
     Returns a result dict on success, or None if no reservation was secured.
     """
     found_event = asyncio.Event()
+    effective_release_at = release_at or (task.launch.release_at if task.launch else None)
+    launch_newly_released_only = bool(task.launch and task.launch.newly_released_only)
     log.info(
         "[%s] Starting snipe — %d target(s) to watch",
         task.url, len(task.targets),
@@ -599,29 +638,52 @@ async def snipe_task(
         if interactive_login:
             await _interactive_login(context, PAGE_LOAD_TIMEOUT)
 
+        resolved_task = task
+        if effective_release_at and launch_newly_released_only:
+            scout = await context.new_page()
+            await _apply_stealth(scout)
+            try:
+                before_dates = await _capture_available_dates(scout, task.url, task.size)
+                await _wait_for_release(effective_release_at, timezone=timezone)
+                after_dates = await _capture_available_dates(scout, task.url, task.size)
+            finally:
+                await scout.close()
+
+            eligible_dates = _newly_released_dates(
+                before=before_dates,
+                after=after_dates,
+                requested_dates=_requested_dates_from_task(task),
+            )
+            if not eligible_dates:
+                log.info("[%s] No newly released eligible dates found.", task.url)
+                await browser.close()
+                return None
+            resolved_task = task.filter_dates(eligible_dates)
+
         # Open one tab per target
         workers: List[DayWorker] = []
-        for i, target in enumerate(task.targets):
+        expanded_targets = resolved_task.expand_targets()
+        for i, target in enumerate(expanded_targets):
             page = await context.new_page()
             await _apply_stealth(page)
-            workers.append(DayWorker(task, target, page, found_event, dry_run=dry_run, interval=interval, prompt_login=prompt_login))
-            if i < len(task.targets) - 1:
+            workers.append(DayWorker(resolved_task, target, page, found_event, dry_run=dry_run, interval=interval, prompt_login=prompt_login))
+            if i < len(expanded_targets) - 1:
                 await asyncio.sleep(LAUNCH_STAGGER_SEC)
 
         # Pre-warm all pages in release mode so they're loaded before the countdown ends
-        if release_at:
-            log.info("[%s] Pre-warming %d worker pages...", task.url, len(workers))
+        if effective_release_at and not launch_newly_released_only:
+            log.info("[%s] Pre-warming %d worker pages...", resolved_task.url, len(workers))
             for w in workers:
                 try:
                     await w.page.goto(
-                        w.target.search_url(task.url, task.size),
+                        w.target.search_url(resolved_task.url, resolved_task.size),
                         wait_until="domcontentloaded",
                         timeout=PAGE_LOAD_TIMEOUT,
                     )
                 except Exception as e:
-                    log.warning("[%s/%s] Pre-warm failed: %s", task.url, w.target.date, e)
+                    log.warning("[%s/%s] Pre-warm failed: %s", resolved_task.url, w.target.date, e)
 
-            await _wait_for_release(release_at, timezone=timezone)
+            await _wait_for_release(effective_release_at, timezone=timezone)
 
         # Run all workers concurrently
         timed_out = False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,7 +4,7 @@ import argparse
 import sys, os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from main import _build_inline_task
+from main import _build_inline_task, _build_parser
 
 
 def test_build_inline_task_uses_date_and_exact_time_flags():
@@ -50,5 +50,50 @@ def test_build_inline_task_preserves_legacy_target_input():
             "dates": ["2026-03-15"],
             "earliest_time": "5:00 PM",
             "latest_time": "9:30 PM",
+        }
+    ]
+
+
+def test_parser_accepts_plural_comma_separated_lists():
+    parser = _build_parser()
+
+    args = parser.parse_args([
+        "run",
+        "taneda",
+        "--size", "3",
+        "--dates", "2026-05-27,2026-05-28,2026-05-29",
+        "--exact-times", "5:15 PM,7:45 PM",
+        "--release-at", "11:00",
+        "--newly-released-only",
+    ])
+
+    task = _build_inline_task(args)
+
+    assert [selector.to_dict() for selector in task.selectors] == [
+        {
+            "dates": ["2026-05-27", "2026-05-28", "2026-05-29"],
+            "exact_times": ["5:15 PM", "7:45 PM"],
+        }
+    ]
+
+
+def test_parser_keeps_legacy_singular_flags_working():
+    parser = _build_parser()
+
+    args = parser.parse_args([
+        "snipe",
+        "taneda",
+        "--date", "2026-05-27",
+        "--date", "2026-05-28",
+        "--exact-time", "5:15 PM",
+        "--exact-time", "7:45 PM",
+    ])
+
+    task = _build_inline_task(args)
+
+    assert [selector.to_dict() for selector in task.selectors] == [
+        {
+            "dates": ["2026-05-27", "2026-05-28"],
+            "exact_times": ["5:15 PM", "7:45 PM"],
         }
     ]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,54 @@
+"""Unit tests for main.py helpers."""
+
+import argparse
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from main import _build_inline_task
+
+
+def test_build_inline_task_uses_date_and_exact_time_flags():
+    args = argparse.Namespace(
+        slug="taneda",
+        size="2",
+        target=None,
+        date=["2026-06-17", "2026-06-18"],
+        exact_time=["5:15 PM", "7:45 PM"],
+        release_at="11:00",
+        newly_released_only=True,
+    )
+
+    task = _build_inline_task(args)
+
+    assert task.launch is not None
+    assert task.launch.release_at == "11:00"
+    assert task.launch.newly_released_only is True
+    assert [selector.to_dict() for selector in task.selectors] == [
+        {
+            "dates": ["2026-06-17", "2026-06-18"],
+            "exact_times": ["5:15 PM", "7:45 PM"],
+        }
+    ]
+
+
+def test_build_inline_task_preserves_legacy_target_input():
+    args = argparse.Namespace(
+        slug="canlis",
+        size="2",
+        target=[["2026-03-15", "5:00 PM", "9:30 PM", "4"]],
+        date=[],
+        exact_time=[],
+        release_at=None,
+        newly_released_only=False,
+    )
+
+    task = _build_inline_task(args)
+
+    assert task.size == "4"
+    assert [selector.to_dict() for selector in task.selectors] == [
+        {
+            "dates": ["2026-03-15"],
+            "earliest_time": "5:00 PM",
+            "latest_time": "9:30 PM",
+        }
+    ]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -56,3 +56,97 @@ def test_task_empty_targets():
     task = Task(url="taneda", size="2")
     assert task.targets == []
     assert task.to_dict() == {"url": "taneda", "size": "2", "targets": []}
+
+
+def test_selector_expands_dates_and_exact_times():
+    from models import Selector
+
+    selector = Selector(
+        dates=["2026-06-17", "2026-06-18"],
+        exact_times=["5:15 PM", "7:45 PM"],
+    )
+
+    targets = selector.expand_targets()
+
+    assert [(t.date, t.exact_time) for t in targets] == [
+        ("2026-06-17", "5:15 PM"),
+        ("2026-06-17", "7:45 PM"),
+        ("2026-06-18", "5:15 PM"),
+        ("2026-06-18", "7:45 PM"),
+    ]
+    assert all(t.earliest_time == t.latest_time for t in targets)
+
+
+def test_task_from_dict_accepts_selector_shape():
+    task = Task.from_dict({
+        "url": "taneda",
+        "size": "2",
+        "launch": {"release_at": "11:00", "newly_released_only": True},
+        "selectors": [
+            {
+                "dates": ["2026-06-17"],
+                "exact_times": ["5:15 PM", "7:45 PM"],
+            }
+        ],
+    })
+
+    assert task.launch is not None
+    assert task.launch.release_at == "11:00"
+    assert task.launch.newly_released_only is True
+    assert len(task.expand_targets()) == 2
+
+
+def test_task_from_dict_translates_legacy_targets():
+    task = Task.from_dict({
+        "url": "canlis",
+        "size": "2",
+        "targets": [
+            {
+                "date": "2026-03-15",
+                "earliest_time": "5:00 PM",
+                "latest_time": "9:30 PM",
+            }
+        ],
+    })
+
+    selector = task.selectors[0]
+    assert selector.dates == ["2026-03-15"]
+    assert selector.earliest_time == "5:00 PM"
+    assert selector.latest_time == "9:30 PM"
+
+
+def test_task_inline_selector_defaults_to_any_time_when_exact_times_missing():
+    from models import Selector
+
+    task = Task(
+        url="taneda",
+        size="2",
+        selectors=[Selector(dates=["2026-06-17"])],
+    )
+
+    targets = task.expand_targets()
+
+    assert len(targets) == 1
+    assert targets[0].date == "2026-06-17"
+    assert targets[0].earliest_time == "12:00 PM"
+    assert targets[0].latest_time == "11:00 PM"
+
+
+def test_task_filter_dates_preserves_exact_times():
+    from models import Selector
+
+    task = Task(
+        url="taneda",
+        size="2",
+        selectors=[
+            Selector(
+                dates=["2026-06-17", "2026-06-18"],
+                exact_times=["5:15 PM", "7:45 PM"],
+            )
+        ],
+    )
+
+    filtered = task.filter_dates(["2026-06-18"])
+
+    assert [t.date for t in filtered.expand_targets()] == ["2026-06-18", "2026-06-18"]
+    assert [t.exact_time for t in filtered.expand_targets()] == ["5:15 PM", "7:45 PM"]

--- a/tests/test_sniper.py
+++ b/tests/test_sniper.py
@@ -7,13 +7,14 @@ these tests run instantly without launching Chrome.
 
 import asyncio
 import time
+import warnings
 import sys, os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from models import Task, Target
+from models import Selector, Task, Target
 from sniper import DayWorker
 
 
@@ -21,8 +22,12 @@ from sniper import DayWorker
 
 @pytest.fixture
 def task():
-    return Task(url="alinea", size="2", targets=[
-        Target(date="2026-03-15", earliest_time="5:00 PM", latest_time="9:30 PM"),
+    return Task(url="alinea", size="2", selectors=[
+        Selector(
+            dates=["2026-03-15"],
+            earliest_time="5:00 PM",
+            latest_time="9:30 PM",
+        ),
     ])
 
 @pytest.fixture
@@ -70,8 +75,12 @@ def _make_page(slots: list) -> AsyncMock:
 
 def _make_worker(task=None, target=None, page=None, dry_run=False) -> DayWorker:
     if task is None:
-        task = Task(url="canlis", size="2", targets=[
-            Target(date="2026-03-15", earliest_time="5:00 PM", latest_time="9:30 PM"),
+        task = Task(url="canlis", size="2", selectors=[
+            Selector(
+                dates=["2026-03-15"],
+                earliest_time="5:00 PM",
+                latest_time="9:30 PM",
+            ),
         ])
     if target is None:
         target = task.targets[0]
@@ -230,8 +239,12 @@ class TestFoundEvent:
         """If found_event is already set, run() exits without polling."""
         page = AsyncMock()
         page.goto = AsyncMock()
-        task = Task(url="canlis", size="2", targets=[
-            Target(date="2026-03-15", earliest_time="5:00 PM", latest_time="9:30 PM"),
+        task = Task(url="canlis", size="2", selectors=[
+            Selector(
+                dates=["2026-03-15"],
+                earliest_time="5:00 PM",
+                latest_time="9:30 PM",
+            ),
         ])
         target = task.targets[0]
         event = asyncio.Event()
@@ -325,6 +338,48 @@ async def test_day_worker_polls_immediately_first_iteration(task, target):
     # Worker should have called page.goto (attempted a poll) within 2 seconds
     assert page.goto.called, "Worker never attempted to poll"
     assert elapsed < 3.0, f"Worker took {elapsed:.1f}s — should poll immediately, not sleep first"
+
+
+@pytest.mark.asyncio
+async def test_exact_time_clicks_only_exact_match():
+    early = _make_slot_element("5:00 PM")
+    exact = _make_slot_element("5:15 PM")
+    later = _make_slot_element("7:45 PM")
+    page = _make_page([early, exact, later])
+    target = Target(
+        date="2026-06-17",
+        earliest_time="5:15 PM",
+        latest_time="5:15 PM",
+        exact_time="5:15 PM",
+    )
+    worker = _make_worker(target=target, page=page)
+
+    result = await worker._try_time()
+
+    assert result is True
+    early.click.assert_not_awaited()
+    exact.click.assert_awaited_once()
+    later.click.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_exact_time_ignores_non_exact_slots_inside_window():
+    inside_window = _make_slot_element("6:00 PM")
+    exact = _make_slot_element("7:45 PM")
+    page = _make_page([inside_window, exact])
+    target = Target(
+        date="2026-06-17",
+        earliest_time="5:15 PM",
+        latest_time="9:30 PM",
+        exact_time="7:45 PM",
+    )
+    worker = _make_worker(target=target, page=page)
+
+    result = await worker._try_time()
+
+    assert result is True
+    inside_window.click.assert_not_awaited()
+    exact.click.assert_awaited_once()
 
 
 # ── _extract_next_data tests ─────────────────────────────────────────────────
@@ -460,6 +515,28 @@ class TestExtractNextData:
         assert result is not None
         assert "6:00 PM" in result
         assert "8:30 PM" in result
+
+
+def test_parse_next_data_json_returns_none_for_non_dict():
+    from sniper import _parse_next_data_json
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = _parse_next_data_json(AsyncMock())
+
+    assert result is None
+    assert caught == []
+
+
+def test_newly_released_dates_applies_delta_and_filter():
+    from sniper import _newly_released_dates
+
+    result = _newly_released_dates(
+        before={"2026-06-10", "2026-06-11"},
+        after={"2026-06-10", "2026-06-11", "2026-06-17", "2026-06-18"},
+        requested_dates=["2026-06-17", "2026-06-19"],
+    )
+
+    assert result == ["2026-06-17"]
 
 
 # ── _poll() with __NEXT_DATA__ pre-filter tests ─────────────────────────────


### PR DESCRIPTION
## Summary
- add selector-based targeting with compact date lists, optional exact times, and launch config
- add newly-released-only launch filtering and deterministic exact-time matching in the sniper runtime
- update README and add spec/plan docs for the new Taneda-style launch workflow

## Test Plan
- venv/bin/pytest tests/ --ignore=tests/integration -q
- PLAYWRIGHT_HEADLESS=1 venv/bin/pytest tests/integration/test_smoke.py -q -s
- live headed snipe against Surrell for 2026-05-13 6:00 PM and 2026-05-15 7:00 PM (party size 2) confirmed click-and-hold behavior