### PR TITLE
feat: add OpenClaw skill and CDP mode

### DIFF
--- a/.agents/skills/tock-sniper/SKILL.md
+++ b/.agents/skills/tock-sniper/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: tock-sniper
+description: Use when the user wants to run the Tock reservation sniper for a timed release or cancellation watch, locally on their Mac or on a remote node.
+---
+
+# Tock Sniper
+
+## Quick Start
+
+Generate one concrete `t0cksn1per` command and run it. Do not reimplement reservation logic in the skill.
+
+Prefer:
+
+- local plus headed when the user wants a visible browser or checkout handoff
+- node plus headless when the user wants unattended polling
+- CDP only when the user explicitly wants to use an existing local Chrome
+
+## Command Source
+
+Run the latest repo version with:
+
+```bash
+uvx --from git+https://github.com/murphykobe/T0ckSn1per t0cksn1per --help
+```
+
+## What To Gather
+
+- restaurant slug
+- party size
+- launch time or restock mode
+- exact dates or no preference
+- exact times or any time
+- local or node execution target
+- whether CDP is requested
+
+Then produce one command and run it.
+
+## References
+
+- For example commands, read `references/commands.md`
+- For CDP setup, read `references/cdp.md`

--- a/.agents/skills/tock-sniper/references/cdp.md
+++ b/.agents/skills/tock-sniper/references/cdp.md
@@ -1,0 +1,30 @@
+# CDP Mode
+
+Use CDP only when the user explicitly wants to run against an existing Chrome on their Mac.
+
+## Start Chrome With Remote Debugging
+
+```bash
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/tocksn1per-cdp
+```
+
+## Run The CLI Through CDP
+
+```bash
+PLAYWRIGHT_HEADLESS=0 uvx --from git+https://github.com/murphykobe/T0ckSn1per \
+  t0cksn1per run taneda \
+  --size 3 \
+  --release-at 11:00 \
+  --newly-released-only \
+  --dates 2026-05-27,2026-05-28,2026-05-29,2026-05-30,2026-05-31 \
+  --exact-times "5:15 PM,7:45 PM" \
+  --cdp-url http://127.0.0.1:9222
+```
+
+## Notes
+
+- CDP is for local browser reuse, not the default path
+- if Chrome is not started with remote debugging enabled, the attach will fail
+- keep Playwright-managed browser launch as the fallback and default

--- a/.agents/skills/tock-sniper/references/commands.md
+++ b/.agents/skills/tock-sniper/references/commands.md
@@ -1,0 +1,37 @@
+# Command Examples
+
+## Local Headed Launch
+
+```bash
+PLAYWRIGHT_HEADLESS=0 uvx --from git+https://github.com/murphykobe/T0ckSn1per \
+  t0cksn1per run taneda \
+  --size 3 \
+  --release-at 11:00 \
+  --newly-released-only \
+  --dates 2026-05-27,2026-05-28,2026-05-29,2026-05-30,2026-05-31 \
+  --exact-times "5:15 PM,7:45 PM"
+```
+
+## Node Headless Launch
+
+```bash
+PLAYWRIGHT_HEADLESS=1 uvx --from git+https://github.com/murphykobe/T0ckSn1per \
+  t0cksn1per run taneda \
+  --size 1 \
+  --release-at 11:00 \
+  --newly-released-only \
+  --dates 2026-05-27,2026-05-28,2026-05-29,2026-05-30,2026-05-31
+```
+
+## Local Headed CDP
+
+```bash
+PLAYWRIGHT_HEADLESS=0 uvx --from git+https://github.com/murphykobe/T0ckSn1per \
+  t0cksn1per run taneda \
+  --size 3 \
+  --release-at 11:00 \
+  --newly-released-only \
+  --dates 2026-05-27,2026-05-28,2026-05-29,2026-05-30,2026-05-31 \
+  --exact-times "5:15 PM,7:45 PM" \
+  --cdp-url http://127.0.0.1:9222
+```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ playwright install chromium
 
 This installs a `t0cksn1per` CLI command. You can also run directly with `python main.py`.
 
+For one-off runs without cloning or creating a venv first, you can execute the repo directly with `uvx`:
+
+```bash
+uvx --from git+https://github.com/murphykobe/T0ckSn1per t0cksn1per --help
+```
+
 All subsequent commands assume the venv is active (or use `venv/bin/python3` / `venv/bin/pytest` directly).
 
 ---
@@ -116,6 +122,15 @@ python main.py run taneda \
   --dates 2026-06-17,2026-06-18 \
   --exact-times "5:15 PM,7:45 PM"
 
+# Attach to an existing local Chrome via CDP instead of launching a managed browser
+python main.py run taneda \
+  --size 2 \
+  --release-at 11:00 \
+  --newly-released-only \
+  --dates 2026-06-17,2026-06-18 \
+  --exact-times "5:15 PM,7:45 PM" \
+  --cdp-url http://127.0.0.1:9222
+
 # Dry-run with custom interval
 python main.py run canlis --size 2 --dry-run --interval 15
 ```
@@ -123,6 +138,51 @@ python main.py run canlis --size 2 --dry-run --interval 15
 `--release-at` uses local machine time by default. `--timezone` remains available as an advanced override, but most local runs do not need it.
 
 The `run` subcommand accepts all the same flags as `snipe` (`--interval`, `--max-duration`, `--release-at`, `--newly-released-only`, `--dates`, `--exact-times`, `--timezone`, `--cookies-file`, `--login`, `--prompt-login`, `--json`, `--dry-run`).
+
+---
+
+## OpenClaw Skill
+
+This repo includes an OpenClaw-ready skill at `.agents/skills/tock-sniper/SKILL.md`.
+
+- use local plus headed mode when you want the browser on your Mac
+- use node plus headless mode for unattended polling
+- use CDP only when you explicitly want to attach to an existing local Chrome
+
+The skill shells out to the repo CLI instead of reimplementing reservation logic:
+
+```bash
+uvx --from git+https://github.com/murphykobe/T0ckSn1per t0cksn1per --help
+```
+
+---
+
+## CDP Mode
+
+CDP is an advanced local-only mode for "use my existing Chrome on this Mac" workflows.
+
+Start Chrome with remote debugging enabled:
+
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/tocksn1per-cdp
+```
+
+Then point `t0cksn1per` at that browser:
+
+```bash
+PLAYWRIGHT_HEADLESS=0 uvx --from git+https://github.com/murphykobe/T0ckSn1per \
+  t0cksn1per run taneda \
+  --size 2 \
+  --release-at 11:00 \
+  --newly-released-only \
+  --dates 2026-06-17,2026-06-18 \
+  --exact-times "5:15 PM,7:45 PM" \
+  --cdp-url http://127.0.0.1:9222
+```
+
+If `--cdp-url` is omitted, the CLI keeps using its normal Playwright-managed browser.
 
 ---
 
@@ -190,6 +250,7 @@ All optional. Set in your shell or a `.env` file (loaded manually — no `python
 | `--interval SECONDS` | Poll interval in seconds (default: 30)                          |
 | `--max-duration MINUTES` | Stop after this many minutes (0 = unlimited)                |
 | `--release-at HH:MM` | Start sniping at this local machine time                       |
+| `--cdp-url URL`   | Advanced: connect to an existing Chrome/Chromium CDP endpoint     |
 | `--newly-released-only` | In launch mode, target only dates that appear after release |
 | `--timezone TZ`   | Optional advanced override for `--release-at`                      |
 | `--cookies-file FILE` | Path to Netscape cookies file for authentication               |

--- a/docs/superpowers/plans/2026-04-17-openclaw-skill-uvx-cdp.md
+++ b/docs/superpowers/plans/2026-04-17-openclaw-skill-uvx-cdp.md
@@ -1,0 +1,451 @@
+# OpenClaw Skill, Uvx, And CDP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `t0cksn1per` runnable via `uvx` from the Git repo, add a repo-hosted OpenClaw skill that shells out to the CLI, and add optional CDP browser attachment for local Mac execution.
+
+**Architecture:** Keep the CLI as the source of truth and add the thinnest possible layers around it. The repo-hosted skill will generate one concrete command for local, node, or CDP mode. The runtime will gain one optional browser-connection path, `connect_over_cdp`, while reusing the existing worker orchestration after the browser context is created.
+
+**Tech Stack:** Python 3.9+, argparse, asyncio, Playwright async API, uv/uvx-compatible packaging via `pyproject.toml`, Markdown skill docs, pytest
+
+---
+
+## File Structure
+
+- Modify: `pyproject.toml`
+  Add any missing package metadata needed for repo-based `uvx` execution.
+- Modify: `main.py`
+  Add `--cdp-url` to `snipe` and `run`, pass it into the runtime.
+- Modify: `sniper.py`
+  Split browser setup from worker orchestration, add CDP connection support, preserve existing behavior when CDP is absent.
+- Create: `.agents/skills/tock-sniper/SKILL.md`
+  Main OpenClaw skill entry point with concise routing and command-generation guidance.
+- Create: `.agents/skills/tock-sniper/references/commands.md`
+  Example command forms for local, node, launch, and exact-time usage.
+- Create: `.agents/skills/tock-sniper/references/cdp.md`
+  CDP setup details for local Chrome on macOS.
+- Modify: `README.md`
+  Document `uvx` repo execution and the new CDP flag.
+- Modify: `tests/test_main.py`
+  Cover `--cdp-url` parser wiring.
+- Modify: `tests/test_sniper.py`
+  Cover browser-setup branching and CDP attach behavior without launching a real browser.
+
+### Task 1: Make Repo-Based Uvx Execution Explicit
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `README.md`
+
+- [ ] **Step 1: Write a failing packaging smoke note as a test target**
+
+Add this command to the verification checklist in `README.md` so the expected invocation is explicit:
+
+```md
+uvx --from git+https://github.com/murphykobe/T0ckSn1per t0cksn1per --help
+```
+
+- [ ] **Step 2: Run the command to observe current behavior**
+
+Run: `uvx --from . t0cksn1per --help`
+Expected: If it fails, capture the missing metadata or build issue. If it passes already, note that no package-structure change is required.
+
+- [ ] **Step 3: Add minimal package metadata only if required**
+
+If `uvx --from . t0cksn1per --help` fails because of missing metadata, add only the minimal fields needed, for example:
+
+```toml
+[project]
+readme = "README.md"
+license = { text = "MIT" }
+authors = [{ name = "murphykobe" }]
+```
+
+If the command already works, leave `pyproject.toml` unchanged.
+
+- [ ] **Step 4: Update README with the repo-based `uvx` form**
+
+Add a short section:
+
+```md
+## Run From Git
+
+You can run the latest version directly from the repository with:
+
+```bash
+uvx --from git+https://github.com/murphykobe/T0ckSn1per t0cksn1per --help
+```
+```
+
+- [ ] **Step 5: Verify the packaging path**
+
+Run: `uvx --from . t0cksn1per --help`
+Expected: PASS, with CLI help output.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyproject.toml README.md
+git commit -m "docs: add repo-based uvx execution"
+```
+
+### Task 2: Add The CDP CLI Surface
+
+**Files:**
+- Modify: `main.py`
+- Test: `tests/test_main.py`
+
+- [ ] **Step 1: Write the failing parser test**
+
+Add to `tests/test_main.py`:
+
+```python
+def test_parser_accepts_cdp_url_for_run():
+    parser = _build_parser()
+
+    args = parser.parse_args([
+        "run",
+        "taneda",
+        "--size", "3",
+        "--dates", "2026-05-27,2026-05-28",
+        "--exact-times", "5:15 PM,7:45 PM",
+        "--cdp-url", "http://127.0.0.1:9222",
+    ])
+
+    assert args.cdp_url == "http://127.0.0.1:9222"
+```
+
+- [ ] **Step 2: Run the targeted test to verify it fails**
+
+Run: `venv/bin/pytest tests/test_main.py::test_parser_accepts_cdp_url_for_run -v`
+Expected: FAIL with `unrecognized arguments: --cdp-url`.
+
+- [ ] **Step 3: Add the CLI flag to both subcommands**
+
+In `main.py`, add:
+
+```python
+p_snipe.add_argument("--cdp-url",
+                     help="Advanced: connect to an existing Chrome/Chromium CDP endpoint")
+
+p_run.add_argument("--cdp-url",
+                   help="Advanced: connect to an existing Chrome/Chromium CDP endpoint")
+```
+
+- [ ] **Step 4: Pass `cdp_url` into `snipe_all()`**
+
+Update both `snipe_kwargs` blocks:
+
+```python
+cdp_url=getattr(args, "cdp_url", None),
+```
+
+- [ ] **Step 5: Run the parser test**
+
+Run: `venv/bin/pytest tests/test_main.py::test_parser_accepts_cdp_url_for_run -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add main.py tests/test_main.py
+git commit -m "feat: add cdp-url CLI flag"
+```
+
+### Task 3: Add CDP Browser Attachment In The Runtime
+
+**Files:**
+- Modify: `sniper.py`
+- Test: `tests/test_sniper.py`
+
+- [ ] **Step 1: Write the failing runtime tests**
+
+Add to `tests/test_sniper.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_build_browser_context_uses_cdp_when_url_provided():
+    from sniper import _open_browser_context
+
+    playwright = AsyncMock()
+    remote_browser = AsyncMock()
+    existing_context = AsyncMock()
+    remote_browser.contexts = [existing_context]
+    playwright.chromium.connect_over_cdp = AsyncMock(return_value=remote_browser)
+
+    browser, context = await _open_browser_context(playwright, cdp_url="http://127.0.0.1:9222")
+
+    playwright.chromium.connect_over_cdp.assert_awaited_once_with("http://127.0.0.1:9222")
+    assert browser is remote_browser
+    assert context is existing_context
+
+
+@pytest.mark.asyncio
+async def test_build_browser_context_launches_browser_when_cdp_missing():
+    from sniper import _open_browser_context
+
+    playwright = AsyncMock()
+    browser = AsyncMock()
+    context = AsyncMock()
+    playwright.chromium.launch = AsyncMock(return_value=browser)
+    browser.new_context = AsyncMock(return_value=context)
+
+    opened_browser, opened_context = await _open_browser_context(playwright, cdp_url=None)
+
+    playwright.chromium.launch.assert_awaited()
+    browser.new_context.assert_awaited()
+    assert opened_browser is browser
+    assert opened_context is context
+```
+
+- [ ] **Step 2: Run the targeted tests to verify they fail**
+
+Run: `venv/bin/pytest tests/test_sniper.py::test_build_browser_context_uses_cdp_when_url_provided tests/test_sniper.py::test_build_browser_context_launches_browser_when_cdp_missing -v`
+Expected: FAIL because `_open_browser_context` does not exist.
+
+- [ ] **Step 3: Add a focused browser-setup helper**
+
+In `sniper.py`, add:
+
+```python
+async def _open_browser_context(playwright, cdp_url: Optional[str] = None):
+    if cdp_url:
+        browser = await playwright.chromium.connect_over_cdp(cdp_url)
+        if browser.contexts:
+            return browser, browser.contexts[0]
+        context = await browser.new_context(user_agent=USER_AGENT)
+        return browser, context
+
+    launch_kwargs: dict = {"headless": HEADLESS, "args": ["--disable-blink-features=AutomationControlled"]}
+    if CHROME_EXECUTABLE:
+        launch_kwargs["executable_path"] = CHROME_EXECUTABLE
+    browser: Browser = await playwright.chromium.launch(**launch_kwargs)
+    context: BrowserContext = await browser.new_context(user_agent=USER_AGENT)
+    return browser, context
+```
+
+- [ ] **Step 4: Use the helper inside `snipe_task()`**
+
+Replace:
+
+```python
+        _launch_kwargs: dict = {"headless": HEADLESS, "args": ["--disable-blink-features=AutomationControlled"]}
+        if CHROME_EXECUTABLE:
+            _launch_kwargs["executable_path"] = CHROME_EXECUTABLE
+        browser: Browser = await p.chromium.launch(**_launch_kwargs)
+        context: BrowserContext = await browser.new_context(user_agent=USER_AGENT)
+```
+
+with:
+
+```python
+        browser, context = await _open_browser_context(p, cdp_url=cdp_url)
+```
+
+- [ ] **Step 5: Thread `cdp_url` through the runtime signatures**
+
+Add `cdp_url: str = None` to:
+
+```python
+async def snipe_task(..., cdp_url=None) -> Optional[dict]:
+async def snipe_all(..., cdp_url=None) -> list:
+```
+
+And pass it through:
+
+```python
+result = await snipe_task(..., cdp_url=cdp_url)
+```
+
+- [ ] **Step 6: Run the full sniper suite**
+
+Run: `venv/bin/pytest tests/test_sniper.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add sniper.py tests/test_sniper.py
+git commit -m "feat: support attaching to Chrome via CDP"
+```
+
+### Task 4: Add The Repo-Hosted OpenClaw Skill
+
+**Files:**
+- Create: `.agents/skills/tock-sniper/SKILL.md`
+- Create: `.agents/skills/tock-sniper/references/commands.md`
+- Create: `.agents/skills/tock-sniper/references/cdp.md`
+
+- [ ] **Step 1: Create the skill frontmatter and concise trigger**
+
+Create `.agents/skills/tock-sniper/SKILL.md`:
+
+```md
+---
+name: tock-sniper
+description: Use when the user wants to run the Tock reservation sniper for a timed release or cancellation watch, locally on their Mac or on a remote node.
+---
+```
+
+- [ ] **Step 2: Add the core skill workflow**
+
+Append:
+
+```md
+# Tock Sniper
+
+## Quick Start
+
+Generate one concrete `t0cksn1per` command and run it. Do not reimplement reservation logic in the skill.
+
+Prefer:
+
+- local + headed when the user wants a visible browser or checkout handoff
+- node + headless when the user wants unattended polling
+- CDP only when the user explicitly wants to use an existing local Chrome
+
+## Command Source
+
+Run the latest repo version with:
+
+```bash
+uvx --from git+https://github.com/murphykobe/T0ckSn1per t0cksn1per --help
+```
+
+## References
+
+- For example commands, read `references/commands.md`
+- For CDP setup, read `references/cdp.md`
+```
+
+- [ ] **Step 3: Add example command references**
+
+Create `.agents/skills/tock-sniper/references/commands.md`:
+
+```md
+# Command Examples
+
+## Local headed launch
+
+```bash
+PLAYWRIGHT_HEADLESS=0 uvx --from git+https://github.com/murphykobe/T0ckSn1per \
+  t0cksn1per run taneda \
+  --size 3 \
+  --release-at 11:00 \
+  --newly-released-only \
+  --dates 2026-05-27,2026-05-28,2026-05-29,2026-05-30,2026-05-31 \
+  --exact-times "5:15 PM,7:45 PM"
+```
+
+## Node headless launch
+
+```bash
+PLAYWRIGHT_HEADLESS=1 uvx --from git+https://github.com/murphykobe/T0ckSn1per \
+  t0cksn1per run taneda \
+  --size 1 \
+  --release-at 11:00 \
+  --newly-released-only \
+  --dates 2026-05-27,2026-05-28,2026-05-29,2026-05-30,2026-05-31
+```
+```
+
+- [ ] **Step 4: Add CDP reference**
+
+Create `.agents/skills/tock-sniper/references/cdp.md`:
+
+```md
+# CDP Mode
+
+Use CDP only when the user explicitly wants to run against an existing Chrome on their Mac.
+
+Example local Chrome launch on macOS:
+
+```bash
+/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/tocksn1per-cdp
+```
+
+Example CLI usage:
+
+```bash
+PLAYWRIGHT_HEADLESS=0 uvx --from git+https://github.com/murphykobe/T0ckSn1per \
+  t0cksn1per run taneda ... --cdp-url http://127.0.0.1:9222
+```
+```
+
+- [ ] **Step 5: Verify the skill files are readable and concise**
+
+Run: `sed -n '1,220p' .agents/skills/tock-sniper/SKILL.md .agents/skills/tock-sniper/references/commands.md .agents/skills/tock-sniper/references/cdp.md`
+Expected: All files present, concise, and valid Markdown.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .agents/skills/tock-sniper
+git commit -m "feat: add repo-hosted OpenClaw skill for t0cksn1per"
+```
+
+### Task 5: Verify End-To-End Packaging And CLI
+
+**Files:**
+- Modify: `README.md` if needed
+
+- [ ] **Step 1: Run the repo-based `uvx` smoke check**
+
+Run: `uvx --from . t0cksn1per --help`
+Expected: PASS with the CLI help output.
+
+- [ ] **Step 2: Run the local test suite**
+
+Run: `venv/bin/pytest tests/ --ignore=tests/integration -q`
+Expected: PASS.
+
+- [ ] **Step 3: Run one live Playwright smoke test**
+
+Run: `PLAYWRIGHT_HEADLESS=1 venv/bin/pytest tests/integration/test_smoke.py -q -s`
+Expected: PASS with a live calendar load.
+
+- [ ] **Step 4: If feasible, run a non-destructive CDP smoke test**
+
+Start Chrome with:
+
+```bash
+/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/tocksn1per-cdp
+```
+
+Then run:
+
+```bash
+PLAYWRIGHT_HEADLESS=0 venv/bin/python main.py snipe surrell \
+  --target 2026-05-13 "6:00 PM" "6:00 PM" 2 \
+  --dry-run \
+  --max-duration 0.1 \
+  --cdp-url http://127.0.0.1:9222
+```
+
+Expected: CLI attaches to the existing browser and exits cleanly after the dry-run window.
+
+- [ ] **Step 5: Commit any final doc or test adjustments**
+
+```bash
+git add README.md
+git commit -m "test: verify uvx and cdp invocation paths"
+```
+
+## Self-Review
+
+- Spec coverage:
+  - repo-based `uvx` execution is covered in Task 1 and Task 5
+  - repo-hosted skill files are covered in Task 4
+  - optional CDP runtime support is covered in Task 2 and Task 3
+  - local vs node execution guidance is covered in Task 4
+- Placeholder scan:
+  - no `TODO`, `TBD`, or deferred placeholders remain
+  - each task includes concrete file paths, commands, and expected outcomes
+- Type consistency:
+  - `cdp_url` is the only new CLI/runtime field
+  - `_open_browser_context()` is the single browser-setup abstraction
+  - the skill remains a thin wrapper over `t0cksn1per`

--- a/docs/superpowers/specs/2026-04-17-openclaw-skill-uvx-cdp-design.md
+++ b/docs/superpowers/specs/2026-04-17-openclaw-skill-uvx-cdp-design.md
@@ -1,0 +1,235 @@
+# OpenClaw Skill, Uvx Packaging, And CDP Design
+
+## Context
+
+`T0ckSn1per` is now a working Python CLI with:
+
+- an installable console entry point, `t0cksn1per`
+- launch mode, exact-time targeting, and compact date list support
+- a Playwright-managed browser flow that has been validated against live Tock pages
+
+The next step is to make this easy to invoke from OpenClaw as a reusable skill, without requiring a manual clone-and-venv workflow. The user also wants an advanced mode where the automation can run against a Chrome instance on their Mac through CDP rather than always launching a managed Playwright browser.
+
+## Goals
+
+- Package the CLI so it can be executed directly from the Git repository using `uvx`
+- Add a repo-hosted `SKILL.md` that shells out to the CLI instead of reimplementing reservation logic
+- Support two execution targets in the skill:
+  - local execution on the user's Mac
+  - remote execution on a node
+- Add an advanced optional CDP mode that lets the CLI attach to an existing Chrome instance
+- Keep Playwright-managed browser launch as the default path
+
+## Non-Goals
+
+- Publishing to PyPI
+- Rewriting the skill to drive browser actions directly instead of using the CLI
+- Making CDP the default execution path
+- Solving remote browser orchestration beyond selecting where the command runs
+
+## User-Facing Model
+
+The system should have three layers:
+
+1. CLI
+   `t0cksn1per` remains the source of truth for reservation behavior.
+2. Packaging
+   `uvx --from git+https://github.com/<owner>/T0ckSn1per t0cksn1per ...` runs the latest repo version directly.
+3. Skill
+   The OpenClaw skill gathers intent and translates it into one CLI invocation.
+
+The browser runs wherever the CLI command runs:
+
+- if OpenClaw runs the command locally, the browser opens on the Mac
+- if OpenClaw runs the command on a node, the browser opens on that node
+
+## Packaging Design
+
+The repo should be runnable with `uvx` directly from Git.
+
+Target command form:
+
+```bash
+uvx --from git+https://github.com/<owner>/T0ckSn1per t0cksn1per --help
+```
+
+Implementation requirements:
+
+- keep `pyproject.toml` as the package entry point definition
+- ensure all runtime dependencies needed by `t0cksn1per` are installable from the repo
+- add any missing package metadata only if needed for `uvx` execution
+- do not require a tagged release or PyPI publication
+
+The package should always use the latest default branch state for now.
+
+## Skill Design
+
+The skill should live inside this repository as a public, reusable artifact.
+
+Recommended structure:
+
+```text
+openclaw-skill/
+  SKILL.md
+  references/
+    commands.md
+    cdp.md
+```
+
+The skill should stay thin. It should:
+
+- identify whether the user wants a launch run, restock run, or exact-time run
+- identify whether to run locally or on a node
+- identify whether CDP is requested
+- generate one command
+- execute that command using the appropriate environment
+
+The skill should not duplicate booking logic, parsing logic, or reservation heuristics from the CLI.
+
+## Execution Targets
+
+### Local Mode
+
+Use local mode when:
+
+- the user wants a visible browser on their Mac
+- the user wants to complete checkout manually after a hold
+- the user wants to reuse a local Chrome session via CDP
+
+Preferred default:
+
+```bash
+PLAYWRIGHT_HEADLESS=0 uvx --from git+https://github.com/<owner>/T0ckSn1per \
+  t0cksn1per run ...
+```
+
+### Node Mode
+
+Use node mode when:
+
+- the user wants unattended polling
+- the environment is remote
+- visibility on the local Mac is not required
+
+Preferred default:
+
+```bash
+PLAYWRIGHT_HEADLESS=1 uvx --from git+https://github.com/<owner>/T0ckSn1per \
+  t0cksn1per run ...
+```
+
+## CDP Design
+
+CDP is an advanced optional browser-connection mode for local execution.
+
+User-facing contract:
+
+- add `--cdp-url http://127.0.0.1:9222`
+- if present, the CLI connects to an existing browser instead of launching a new managed browser
+- all reservation logic after browser connection stays the same
+
+Example:
+
+```bash
+PLAYWRIGHT_HEADLESS=0 uvx --from git+https://github.com/<owner>/T0ckSn1per \
+  t0cksn1per run taneda \
+  --size 3 \
+  --release-at 11:00 \
+  --newly-released-only \
+  --dates 2026-05-27,2026-05-28,2026-05-29,2026-05-30,2026-05-31 \
+  --exact-times "5:15 PM,7:45 PM" \
+  --cdp-url http://127.0.0.1:9222
+```
+
+Intended use:
+
+- local Mac browser reuse
+- session continuity
+- easier visible handoff during checkout
+
+Constraints:
+
+- CDP mode is optional, not required
+- CDP mode is not the primary path for remote node execution
+- CDP setup is manual and may fail if Chrome is not started with remote debugging enabled
+
+## Runtime Behavior
+
+Default browser connection path:
+
+- `async_playwright()`
+- `p.chromium.launch(...)`
+- `browser.new_context(...)`
+
+CDP browser connection path:
+
+- `async_playwright()`
+- `p.chromium.connect_over_cdp(cdp_url)`
+- select or create a usable browser context
+- continue through the existing worker orchestration path
+
+The rest of the runtime should not care whether the browser was launched or attached.
+
+## CLI Additions
+
+Add one new optional flag to `snipe` and `run`:
+
+- `--cdp-url URL`
+  Connect to an existing Chrome/Chromium debugging endpoint instead of launching a managed browser.
+
+The help text should clearly describe this as an advanced/local option.
+
+## Skill Responsibilities
+
+The skill should translate user intent into one of these command families:
+
+- local headed Playwright
+- node headless Playwright
+- local headed CDP
+
+It should gather:
+
+- restaurant slug
+- party size
+- date preferences or no preference
+- exact times or broad mode
+- launch time if any
+- local or node execution target
+- whether CDP is requested
+
+Then it should produce one concrete command and run it.
+
+## References To Include In The Skill
+
+The skill should keep the main `SKILL.md` concise and move details into references:
+
+- `references/commands.md`
+  Example commands for launch mode, restock mode, local mode, node mode
+- `references/cdp.md`
+  How to start Chrome with remote debugging and when to use CDP
+
+## Testing
+
+Required verification for this work:
+
+- unit or parser tests for the new `--cdp-url` flag
+- a packaging smoke check proving `uvx --from git+... t0cksn1per --help` works
+- a local CLI smoke check proving the command generation examples stay valid
+- if feasible, a non-destructive CDP attach smoke test against a locally started browser
+
+## Rollout
+
+Recommended rollout order:
+
+1. Make repo-based `uvx` execution work
+2. Add the repo-hosted OpenClaw skill
+3. Add CDP as an advanced browser-connection mode
+4. Document local vs node execution clearly in the skill
+
+## Resolved Decisions
+
+- The skill should live inside this repository
+- `uvx` should execute directly from the repository, not from PyPI
+- Using the latest repo state is acceptable for now; tags are not required
+- Playwright-managed browser remains the default
+- CDP is an advanced optional mode for using the user's Mac browser

--- a/main.py
+++ b/main.py
@@ -154,6 +154,7 @@ async def _cmd_snipe(args: argparse.Namespace) -> None:
         interval=args.interval,
         max_duration=args.max_duration,
         release_at=getattr(args, "release_at", None),
+        cdp_url=getattr(args, "cdp_url", None),
         timezone=getattr(args, "timezone", None),
         cookies_file=getattr(args, "cookies_file", None),
         interactive_login=getattr(args, "login", False),
@@ -178,6 +179,7 @@ async def _cmd_run(args: argparse.Namespace) -> None:
         interval=args.interval,
         max_duration=args.max_duration,
         release_at=getattr(args, "release_at", None),
+        cdp_url=getattr(args, "cdp_url", None),
         timezone=getattr(args, "timezone", None),
         cookies_file=getattr(args, "cookies_file", None),
         interactive_login=getattr(args, "login", False),
@@ -229,6 +231,8 @@ def _build_parser() -> argparse.ArgumentParser:
                          help="Stop after this many minutes (0 = unlimited)")
     p_snipe.add_argument("--release-at", metavar="HH:MM",
                          help="Start sniping at this time of day")
+    p_snipe.add_argument("--cdp-url",
+                         help="Advanced: connect to an existing Chrome/Chromium CDP endpoint")
     p_snipe.add_argument("--newly-released-only", action="store_true",
                          help="In launch mode, only target dates that appear after release")
     p_snipe.add_argument("--timezone", metavar="TZ",
@@ -262,6 +266,8 @@ def _build_parser() -> argparse.ArgumentParser:
                        help="Stop after this many minutes (0 = unlimited)")
     p_run.add_argument("--release-at", metavar="HH:MM",
                        help="Start sniping at this time of day")
+    p_run.add_argument("--cdp-url",
+                       help="Advanced: connect to an existing Chrome/Chromium CDP endpoint")
     p_run.add_argument("--newly-released-only", action="store_true",
                        help="In launch mode, only target dates that appear after release")
     p_run.add_argument("--timezone", metavar="TZ",

--- a/sniper.py
+++ b/sniper.py
@@ -53,6 +53,7 @@ PAGE_LOAD_TIMEOUT  = 15_000    # ms
 SLOT_WAIT_TIMEOUT  = 8_000     # ms — wait for time slots after clicking a day
 BROWSER_HOLD_SEC   = 600       # keep browser alive after securing cart (10 min)
 LAUNCH_STAGGER_SEC = 0.5       # delay between spinning up worker tabs
+SHUTDOWN_GRACE_SEC = 5.0       # allow in-flight polls to settle before force-cancel
 
 USER_AGENT = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
@@ -214,6 +215,62 @@ def _newly_released_dates(
     return eligible
 
 
+async def _open_browser_context(playwright, cdp_url: Optional[str] = None):
+    """Open a browser/context pair and return ownership flags for cleanup."""
+    if cdp_url:
+        browser = await playwright.chromium.connect_over_cdp(cdp_url)
+        if browser.contexts:
+            return browser, browser.contexts[0], False, False
+        context = await browser.new_context(user_agent=USER_AGENT)
+        return browser, context, False, True
+
+    launch_kwargs: dict = {"headless": HEADLESS, "args": ["--disable-blink-features=AutomationControlled"]}
+    if CHROME_EXECUTABLE:
+        launch_kwargs["executable_path"] = CHROME_EXECUTABLE
+    browser: Browser = await playwright.chromium.launch(**launch_kwargs)
+    context: BrowserContext = await browser.new_context(user_agent=USER_AGENT)
+    return browser, context, True, True
+
+
+async def _cleanup_browser_session(
+    browser: Browser,
+    context: BrowserContext,
+    pages: list,
+    owns_browser: bool,
+    owns_context: bool,
+) -> None:
+    """Close only the resources owned by this run."""
+    if owns_browser:
+        await browser.close()
+        return
+
+    if owns_context:
+        await context.close()
+        return
+
+    # In CDP attach mode we intentionally leave the user's browser/context open.
+    # Exiting Playwright disconnects the session; force-closing attached pages can
+    # race with in-flight protocol work and surface noisy TargetClosedError logs.
+
+
+async def _stop_worker_tasks(task_url: str, found_event: asyncio.Event, worker_tasks: list) -> None:
+    """Request a graceful stop, then cancel only if workers fail to settle."""
+    found_event.set()
+    try:
+        await asyncio.wait_for(
+            asyncio.gather(*worker_tasks, return_exceptions=True),
+            timeout=SHUTDOWN_GRACE_SEC,
+        )
+        return
+    except asyncio.TimeoutError:
+        log.debug("[%s] Worker shutdown grace period elapsed — cancelling remaining tasks.", task_url)
+
+    for worker_task in worker_tasks:
+        if not worker_task.done():
+            worker_task.cancel()
+    await asyncio.gather(*worker_tasks, return_exceptions=True)
+
+
 # ── Stealth helper ────────────────────────────────────────────────────────────
 
 async def _apply_stealth(page: Page) -> None:
@@ -251,6 +308,25 @@ class DayWorker:
         self.prompt_login = prompt_login
         self.checkout_url: Optional[str] = None
         self.matched_time: Optional[str] = None
+
+    async def _wait_for_selector_until_stop(
+        self,
+        selector: str,
+        timeout_ms: int,
+        step_ms: int = 500,
+    ) -> bool:
+        """Wait for a selector, but bail out quickly once shutdown is requested."""
+        deadline = asyncio.get_running_loop().time() + (timeout_ms / 1000)
+        while not self.found_event.is_set():
+            remaining_ms = int((deadline - asyncio.get_running_loop().time()) * 1000)
+            if remaining_ms <= 0:
+                raise PWTimeout(f"Timeout waiting for selector: {selector}")
+            try:
+                await self.page.wait_for_selector(selector, timeout=min(step_ms, remaining_ms))
+                return True
+            except PWTimeout:
+                continue
+        return False
 
     async def run(self) -> None:
         log.info(
@@ -329,10 +405,12 @@ class DayWorker:
             )
 
         try:
-            await self.page.wait_for_selector(
+            calendar_ready = await self._wait_for_selector_until_stop(
                 "div.ConsumerCalendar-month",
-                timeout=PAGE_LOAD_TIMEOUT,
+                timeout_ms=PAGE_LOAD_TIMEOUT,
             )
+            if not calendar_ready:
+                return False
         except PWTimeout:
             log.debug("[%s/%s] Calendar selector timeout, retrying", self.task.url, self.target.date)
             return False
@@ -371,10 +449,12 @@ class DayWorker:
           data-testid="booking-card-button"    — the Book action button
         """
         try:
-            await self.page.wait_for_selector(
+            results_ready = await self._wait_for_selector_until_stop(
                 "[data-testid='search-result']",
-                timeout=SLOT_WAIT_TIMEOUT,
+                timeout_ms=SLOT_WAIT_TIMEOUT,
             )
+            if not results_ready:
+                return False
             cards = await self.page.query_selector_all("[data-testid='search-result']")
             for card in cards:
                 time_el = await card.query_selector("[data-testid='search-result-time']")
@@ -609,6 +689,7 @@ async def snipe_task(
     interval: float = 30.0,
     max_duration: float = 0,
     release_at=None,
+    cdp_url: str = None,
     timezone: str = None,
     cookies_file=None,
     interactive_login: bool = False,
@@ -627,11 +708,11 @@ async def snipe_task(
     )
 
     async with async_playwright() as p:
-        _launch_kwargs: dict = {"headless": HEADLESS, "args": ["--disable-blink-features=AutomationControlled"]}
-        if CHROME_EXECUTABLE:
-            _launch_kwargs["executable_path"] = CHROME_EXECUTABLE
-        browser: Browser = await p.chromium.launch(**_launch_kwargs)
-        context: BrowserContext = await browser.new_context(user_agent=USER_AGENT)
+        browser, context, owns_browser, owns_context = await _open_browser_context(
+            p,
+            cdp_url=cdp_url,
+        )
+        opened_pages: list = []
 
         if cookies_file:
             await _load_cookies(context, cookies_file)
@@ -641,6 +722,7 @@ async def snipe_task(
         resolved_task = task
         if effective_release_at and launch_newly_released_only:
             scout = await context.new_page()
+            opened_pages.append(scout)
             await _apply_stealth(scout)
             try:
                 before_dates = await _capture_available_dates(scout, task.url, task.size)
@@ -656,7 +738,13 @@ async def snipe_task(
             )
             if not eligible_dates:
                 log.info("[%s] No newly released eligible dates found.", task.url)
-                await browser.close()
+                await _cleanup_browser_session(
+                    browser,
+                    context,
+                    opened_pages,
+                    owns_browser=owns_browser,
+                    owns_context=owns_context,
+                )
                 return None
             resolved_task = task.filter_dates(eligible_dates)
 
@@ -665,6 +753,7 @@ async def snipe_task(
         expanded_targets = resolved_task.expand_targets()
         for i, target in enumerate(expanded_targets):
             page = await context.new_page()
+            opened_pages.append(page)
             await _apply_stealth(page)
             workers.append(DayWorker(resolved_task, target, page, found_event, dry_run=dry_run, interval=interval, prompt_login=prompt_login))
             if i < len(expanded_targets) - 1:
@@ -686,19 +775,24 @@ async def snipe_task(
             await _wait_for_release(effective_release_at, timezone=timezone)
 
         # Run all workers concurrently
-        timed_out = False
-        gather_coro = asyncio.gather(*[w.run() for w in workers], return_exceptions=True)
+        worker_tasks = [asyncio.create_task(w.run()) for w in workers]
         if max_duration > 0:
-            try:
-                await asyncio.wait_for(gather_coro, timeout=max_duration * 60)
-            except asyncio.TimeoutError:
+            done, pending = await asyncio.wait(worker_tasks, timeout=max_duration * 60)
+            if pending:
                 log.info("[%s] max-duration %.0fmin reached — stopping.", task.url, max_duration)
-                timed_out = True
-                found_event.set()  # signal all workers to stop their loops
+                await _stop_worker_tasks(task.url, found_event, worker_tasks)
+            else:
+                await asyncio.gather(*worker_tasks, return_exceptions=True)
         else:
-            await gather_coro
+            await asyncio.gather(*worker_tasks, return_exceptions=True)
 
-        await browser.close()
+        await _cleanup_browser_session(
+            browser,
+            context,
+            opened_pages,
+            owns_browser=owns_browser,
+            owns_context=owns_context,
+        )
 
     # Check if any worker actually found a slot (not just timed out)
     winning_worker = next(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -97,3 +97,18 @@ def test_parser_keeps_legacy_singular_flags_working():
             "exact_times": ["5:15 PM", "7:45 PM"],
         }
     ]
+
+
+def test_parser_accepts_cdp_url_for_run():
+    parser = _build_parser()
+
+    args = parser.parse_args([
+        "run",
+        "taneda",
+        "--size", "3",
+        "--dates", "2026-05-27,2026-05-28",
+        "--exact-times", "5:15 PM,7:45 PM",
+        "--cdp-url", "http://127.0.0.1:9222",
+    ])
+
+    assert args.cdp_url == "http://127.0.0.1:9222"

--- a/tests/test_sniper.py
+++ b/tests/test_sniper.py
@@ -539,6 +539,148 @@ def test_newly_released_dates_applies_delta_and_filter():
     assert result == ["2026-06-17"]
 
 
+@pytest.mark.asyncio
+async def test_open_browser_context_uses_cdp_when_url_provided():
+    from sniper import _open_browser_context
+
+    playwright = AsyncMock()
+    remote_browser = AsyncMock()
+    existing_context = AsyncMock()
+    remote_browser.contexts = [existing_context]
+    playwright.chromium.connect_over_cdp = AsyncMock(return_value=remote_browser)
+
+    browser, context, owns_browser, owns_context = await _open_browser_context(
+        playwright,
+        cdp_url="http://127.0.0.1:9222",
+    )
+
+    playwright.chromium.connect_over_cdp.assert_awaited_once_with("http://127.0.0.1:9222")
+    assert browser is remote_browser
+    assert context is existing_context
+    assert owns_browser is False
+    assert owns_context is False
+
+
+@pytest.mark.asyncio
+async def test_open_browser_context_launches_browser_when_cdp_missing():
+    from sniper import _open_browser_context
+
+    playwright = AsyncMock()
+    browser = AsyncMock()
+    context = AsyncMock()
+    playwright.chromium.launch = AsyncMock(return_value=browser)
+    browser.new_context = AsyncMock(return_value=context)
+
+    opened_browser, opened_context, owns_browser, owns_context = await _open_browser_context(
+        playwright,
+        cdp_url=None,
+    )
+
+    playwright.chromium.launch.assert_awaited()
+    browser.new_context.assert_awaited()
+    assert opened_browser is browser
+    assert opened_context is context
+    assert owns_browser is True
+    assert owns_context is True
+
+
+class _FakePlaywrightContextManager:
+    def __init__(self, playwright):
+        self._playwright = playwright
+
+    async def __aenter__(self):
+        return self._playwright
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_snipe_task_cancels_workers_before_browser_close():
+    from sniper import snipe_task
+
+    order = []
+    browser = AsyncMock()
+    context = AsyncMock()
+    page = AsyncMock()
+    context.new_page = AsyncMock(return_value=page)
+
+    async def _close_browser():
+        order.append("browser.close")
+
+    browser.close = AsyncMock(side_effect=_close_browser)
+
+    class FakeWorker:
+        def __init__(self, task, target, page, found_event, dry_run=False, interval=30.0, prompt_login=False):
+            self.task = task
+            self.target = target
+            self.page = page
+            self.checkout_url = None
+
+        async def run(self):
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                order.append("worker.cancelled")
+                raise
+
+    with patch("sniper.async_playwright", return_value=_FakePlaywrightContextManager(AsyncMock())):
+        with patch("sniper._open_browser_context", AsyncMock(return_value=(browser, context, True, True))):
+            with patch("sniper._apply_stealth", AsyncMock()):
+                with patch("sniper.DayWorker", FakeWorker):
+                    task = Task(url="alinea", size="2", selectors=[
+                        Selector(
+                            dates=["2026-03-15"],
+                            earliest_time="5:00 PM",
+                            latest_time="9:30 PM",
+                        ),
+                    ])
+
+                    result = await snipe_task(task, dry_run=True, max_duration=0.001)
+
+    assert result is None
+    assert order == ["worker.cancelled", "browser.close"]
+
+
+@pytest.mark.asyncio
+async def test_snipe_task_does_not_close_attached_cdp_browser():
+    from sniper import snipe_task
+
+    browser = AsyncMock()
+    context = AsyncMock()
+    page = AsyncMock()
+    context.new_page = AsyncMock(return_value=page)
+
+    class FakeWorker:
+        def __init__(self, task, target, page, found_event, dry_run=False, interval=30.0, prompt_login=False):
+            self.task = task
+            self.target = target
+            self.page = page
+            self.checkout_url = None
+
+        async def run(self):
+            return None
+
+    with patch("sniper.async_playwright", return_value=_FakePlaywrightContextManager(AsyncMock())):
+        with patch("sniper._open_browser_context", AsyncMock(return_value=(browser, context, False, False))):
+            with patch("sniper._apply_stealth", AsyncMock()):
+                with patch("sniper.DayWorker", FakeWorker):
+                    task = Task(url="alinea", size="2", selectors=[
+                        Selector(
+                            dates=["2026-03-15"],
+                            earliest_time="5:00 PM",
+                            latest_time="9:30 PM",
+                        ),
+                    ])
+
+                    result = await snipe_task(task, dry_run=True, max_duration=0.001)
+
+    assert result is None
+    browser.close.assert_not_awaited()
+    context.close.assert_not_awaited()
+    page.close.assert_not_awaited()
+
+
 # ── _poll() with __NEXT_DATA__ pre-filter tests ─────────────────────────────
 
 class TestPollWithNextData:
@@ -594,6 +736,28 @@ class TestPollWithNextData:
 
         assert result is True
         worker._try_day.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_selector_until_stop_exits_when_found_event_set():
+    from playwright.async_api import TimeoutError as PWTimeout
+
+    page = AsyncMock()
+    worker = _make_worker(page=page)
+
+    async def _wait_side_effect(*args, **kwargs):
+        worker.found_event.set()
+        raise PWTimeout("not yet")
+
+    page.wait_for_selector = AsyncMock(side_effect=_wait_side_effect)
+
+    result = await worker._wait_for_selector_until_stop(
+        "div.ConsumerCalendar-month",
+        timeout_ms=1_000,
+        step_ms=10,
+    )
+
+    assert result is False
 
     @pytest.mark.asyncio
     async def test_poll_falls_back_to_dom_when_next_data_unavailable(self):


### PR DESCRIPTION
Summary
- add a repo-hosted OpenClaw tock-sniper skill with command and CDP references
- support repo-based uvx execution and document the workflow in the README
- add optional cdp-url browser attachment with safer shutdown behavior for attached Chrome sessions

Verification
- venv/bin/pytest tests/ --ignore=tests/integration -q
- PLAYWRIGHT_HEADLESS=1 venv/bin/pytest tests/integration/test_smoke.py -q -s
- uvx --from . t0cksn1per --help
- live CDP dry-run against local Chrome