### PR TITLE
feat: monitoring mode, 60-day forward recon, date ranges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run unit tests
+        run: pytest tests/ --ignore=tests/integration -v

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ There are three subcommands. The Tock restaurant **slug** is the path segment fr
 
 ### `recon` — discover available dates
 
-Scrapes the restaurant's Tock calendar and prints (or saves) a JSON task config.
+Scrapes the restaurant's Tock calendar and prints (or saves) a JSON task config. `recon` looks ahead 60 calendar days by default instead of only checking the current month.
 
 ```bash
 # Print discovered availability (either form works)
@@ -76,7 +76,7 @@ If `ANTHROPIC_API_KEY` is set, Claude will refine the time window. Otherwise a b
 
 ### `snipe` — snipe from a saved config or inline targets
 
-Loads a JSON config from `recon`, or accepts inline `--target` flags, compact `--dates` lists, and optional deterministic `--exact-times` values.
+Loads a JSON config from `recon`, or accepts inline `--target` flags, compact `--dates` / `--date-ranges` filters, optional deterministic `--exact-times` values, and explicit monitoring mode.
 
 ```bash
 # Live snipe from a config file
@@ -91,6 +91,18 @@ python main.py snipe canlis \
 python main.py snipe taneda \
   --dates 2026-06-17,2026-06-18 \
   --exact-times "5:15 PM,7:45 PM"
+
+# Compact ranges: expand date windows without listing every day
+python main.py snipe taneda \
+  --date-ranges "2026-05-07:2026-05-09,2026-05-21:2026-05-25" \
+  --exact-times "5:15 PM,7:45 PM"
+
+# Monitoring mode: keep polling a known target window for restocks/cancellations
+python main.py snipe taneda \
+  --dates 2026-05-21,2026-05-22 \
+  --monitor \
+  --monitor-duration 15 \
+  --interval 5
 
 # Dry-run: finds slots but does not click them
 python main.py snipe --config canlis.json --dry-run
@@ -128,6 +140,20 @@ python main.py run taneda \
   --release-at 11:00 \
   --newly-released-only
 
+# No date preference but deterministic seatings: target the next 30 calendar days by default
+python main.py run taneda \
+  --size 1 \
+  --release-at 11:00 \
+  --newly-released-only \
+  --exact-times "5:15 PM,7:45 PM"
+
+# Regular monitoring: recon the next 60 days, then keep polling what is eligible now
+python main.py run taneda \
+  --size 1 \
+  --monitor \
+  --monitor-duration 15 \
+  --interval 5
+
 # Attach to an existing local Chrome via CDP instead of launching a managed browser
 python main.py run taneda \
   --size 2 \
@@ -142,6 +168,11 @@ python main.py run canlis --size 2 --dry-run --interval 15
 ```
 
 `--release-at` uses local machine time by default. `--timezone` remains available as an advanced override, but most local runs do not need it.
+
+Default windows:
+- launch mode without explicit dates targets the next 30 calendar days
+- regular `recon` and `run` look ahead 60 calendar days
+- `--monitor-duration` defaults to 15 minutes
 
 The `run` subcommand accepts all the same flags as `snipe` (`--interval`, `--max-duration`, `--release-at`, `--newly-released-only`, `--dates`, `--exact-times`, `--timezone`, `--cookies-file`, `--login`, `--prompt-login`, `--json`, `--dry-run`).
 
@@ -249,12 +280,15 @@ All optional. Set in your shell or a `.env` file (loaded manually — no `python
 |-------------------|--------------------------------------------------------------------|
 | `--target DATE EARLIEST LATEST SIZE` | Inline target (repeatable). Example: `--target 2026-03-14 "5:00 PM" "9:30 PM" 2` |
 | `--dates YYYY-MM-DD,YYYY-MM-DD` | Comma-separated compact date filter |
+| `--date-ranges YYYY-MM-DD:YYYY-MM-DD,...` | Comma-separated inclusive date ranges |
 | `--exact-times "H:MM AM/PM,H:MM AM/PM"` | Comma-separated deterministic exact start times |
 | `--date YYYY-MM-DD` | Legacy repeatable date flag, still supported |
 | `--exact-time "H:MM AM/PM"` | Legacy repeatable exact-time flag, still supported |
 | `--config FILE`   | JSON config file from `recon`                                      |
 | `--interval SECONDS` | Poll interval in seconds (default: 30)                          |
 | `--max-duration MINUTES` | Stop after this many minutes (0 = unlimited)                |
+| `--monitor`       | Keep polling for cancellations/restocks instead of exiting after one pass |
+| `--monitor-duration MINUTES` | Monitoring window in minutes (default: 15)            |
 | `--release-at HH:MM` | Start sniping at this local machine time                       |
 | `--cdp-url URL`   | Advanced: connect to an existing Chrome/Chromium CDP endpoint     |
 | `--newly-released-only` | In launch mode, target only dates that appear after release |
@@ -279,9 +313,10 @@ venv/bin/pytest tests/ --ignore=tests/integration -v
 
 | File | What it covers |
 |---|---|
-| `tests/test_models.py` | URL building, time-window parsing, JSON round-trip (5 tests) |
-| `tests/test_recon.py` | `_parse_time`, `_time_str`, `_build_tasks`, `__NEXT_DATA__` parser (19 tests) |
-| `tests/test_sniper.py` | `DayWorker._try_time`, `_extract_next_data`, `_poll` pre-filter, `_any_slot_in_window`, cart verification, cookies (41 tests) |
+| `tests/test_models.py` | URL building, time-window parsing, JSON round-trip, date-range expansion |
+| `tests/test_main.py` | CLI parsing, inline task construction, runtime kwarg wiring |
+| `tests/test_recon.py` | `_parse_time`, `_time_str`, `_build_tasks`, forward-window month scanning, `__NEXT_DATA__` parsing |
+| `tests/test_sniper.py` | `DayWorker._try_time`, `_extract_next_data`, launch monitoring, worker cleanup, `_poll` pre-filter, cart verification, cookies |
 
 All Playwright interactions are replaced with `AsyncMock` — the suite runs in ~2 s.
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ python main.py run taneda \
   --dates 2026-06-17,2026-06-18 \
   --exact-times "5:15 PM,7:45 PM"
 
+# No date preference: target any newly released date for this party size
+python main.py run taneda \
+  --size 1 \
+  --release-at 11:00 \
+  --newly-released-only
+
 # Attach to an existing local Chrome via CDP instead of launching a managed browser
 python main.py run taneda \
   --size 2 \

--- a/docs/superpowers/plans/2026-04-18-monitoring-and-forward-window.md
+++ b/docs/superpowers/plans/2026-04-18-monitoring-and-forward-window.md
@@ -1,0 +1,616 @@
+# Monitoring And Forward Window Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add forward-looking recon, persistent launch monitoring, explicit monitoring mode, and compact date-range input so the sniper can keep watching for newly released slots and expired-hold returns instead of exiting after one pass.
+
+**Architecture:** Keep the existing CLI and worker engine, but expand the targeting layer so it can build dates from explicit lists, date ranges, or forward windows. Extend recon to scan multiple months ahead, then teach the runtime to keep refreshing eligible dates for a bounded monitoring duration in both launch and regular monitoring modes.
+
+**Tech Stack:** Python 3.9+, argparse, asyncio, Playwright async API, dataclasses in `models.py`, pytest
+
+---
+
+## File Structure
+
+- Modify: `main.py`
+  Add CLI flags and routing helpers for monitoring mode, date ranges, and default forward windows.
+- Modify: `models.py`
+  Add helpers for expanding date ranges and handling empty-date selectors against eligible windows.
+- Modify: `recon.py`
+  Replace single-month scraping with forward-window scanning across multiple months.
+- Modify: `sniper.py`
+  Add persistent monitoring loops for launch and regular modes, plus better status logging.
+- Modify: `README.md`
+  Document launch monitoring, monitoring mode, date ranges, and default windows.
+- Modify: `tests/test_main.py`
+  Cover CLI routing, no-date defaults, and date-range parsing.
+- Modify: `tests/test_models.py`
+  Cover date-range expansion and forward-window selector behavior.
+- Modify: `tests/test_recon.py`
+  Cover forward-window date collection and task generation expectations.
+- Modify: `tests/test_sniper.py`
+  Cover persistent monitoring behavior and launch-mode retry semantics.
+
+### Task 1: Add Date Range And Window Helpers
+
+**Files:**
+- Modify: `models.py`
+- Test: `tests/test_models.py`
+
+- [ ] **Step 1: Write the failing model tests**
+
+Add to `tests/test_models.py`:
+
+```python
+from models import expand_date_ranges
+
+
+def test_expand_date_ranges_supports_multiple_ranges():
+    dates = expand_date_ranges("2026-05-07:2026-05-09,2026-05-21:2026-05-25")
+    assert dates == [
+        "2026-05-07",
+        "2026-05-08",
+        "2026-05-09",
+        "2026-05-21",
+        "2026-05-22",
+        "2026-05-23",
+        "2026-05-24",
+        "2026-05-25",
+    ]
+
+
+def test_expand_date_ranges_returns_empty_for_blank_input():
+    assert expand_date_ranges(None) == []
+    assert expand_date_ranges("") == []
+```
+
+- [ ] **Step 2: Run the targeted tests to verify they fail**
+
+Run: `venv/bin/pytest tests/test_models.py::test_expand_date_ranges_supports_multiple_ranges tests/test_models.py::test_expand_date_ranges_returns_empty_for_blank_input -v`
+Expected: FAIL because `expand_date_ranges` does not exist.
+
+- [ ] **Step 3: Add the minimal date-range helper**
+
+In `models.py`, add:
+
+```python
+from datetime import datetime, timedelta
+
+
+def expand_date_ranges(raw: Optional[str]) -> List[str]:
+    if not raw:
+        return []
+
+    expanded: List[str] = []
+    for part in [p.strip() for p in raw.split(",") if p.strip()]:
+        start_s, end_s = [token.strip() for token in part.split(":", 1)]
+        start = datetime.strptime(start_s, "%Y-%m-%d").date()
+        end = datetime.strptime(end_s, "%Y-%m-%d").date()
+        cursor = start
+        while cursor <= end:
+            expanded.append(cursor.isoformat())
+            cursor += timedelta(days=1)
+    return expanded
+```
+
+- [ ] **Step 4: Run the targeted tests to verify they pass**
+
+Run: `venv/bin/pytest tests/test_models.py::test_expand_date_ranges_supports_multiple_ranges tests/test_models.py::test_expand_date_ranges_returns_empty_for_blank_input -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add models.py tests/test_models.py
+git commit -m "feat: add date range expansion helpers"
+```
+
+### Task 2: Add CLI Surface For Monitoring And Date Ranges
+
+**Files:**
+- Modify: `main.py`
+- Test: `tests/test_main.py`
+
+- [ ] **Step 1: Write the failing parser and routing tests**
+
+Add to `tests/test_main.py`:
+
+```python
+def test_parser_accepts_monitoring_flags_and_date_ranges():
+    parser = _build_parser()
+
+    args = parser.parse_args([
+        "run",
+        "taneda",
+        "--size", "1",
+        "--monitor",
+        "--monitor-duration", "20",
+        "--date-ranges", "2026-05-07:2026-05-09",
+    ])
+
+    assert args.monitor is True
+    assert args.monitor_duration == 20
+    assert args.date_ranges == "2026-05-07:2026-05-09"
+
+
+def test_build_inline_task_expands_date_ranges():
+    args = argparse.Namespace(
+        slug="taneda",
+        size="1",
+        target=None,
+        date=[],
+        dates=None,
+        date_ranges="2026-05-07:2026-05-09",
+        exact_time=[],
+        exact_times=None,
+        release_at=None,
+        newly_released_only=False,
+        monitor=True,
+        monitor_duration=15,
+    )
+
+    task = _build_inline_task(args)
+
+    assert [selector.to_dict() for selector in task.selectors] == [
+        {"dates": ["2026-05-07", "2026-05-08", "2026-05-09"]}
+    ]
+```
+
+- [ ] **Step 2: Run the targeted tests to verify they fail**
+
+Run: `venv/bin/pytest tests/test_main.py::test_parser_accepts_monitoring_flags_and_date_ranges tests/test_main.py::test_build_inline_task_expands_date_ranges -v`
+Expected: FAIL because the parser does not know `--monitor`, `--monitor-duration`, or `--date-ranges`.
+
+- [ ] **Step 3: Add the CLI flags and date collection logic**
+
+In `main.py`, add these parser flags to both `snipe` and `run`:
+
+```python
+p_snipe.add_argument("--date-ranges",
+                     help="Comma-separated date ranges, e.g. '2026-05-07:2026-05-09,2026-05-21:2026-05-25'")
+p_snipe.add_argument("--monitor", action="store_true",
+                     help="Keep polling for cancellations/restocks instead of exiting after one pass")
+p_snipe.add_argument("--monitor-duration", type=float, default=15.0, metavar="MINUTES",
+                     help="Monitoring duration in minutes (default: 15)")
+```
+
+Add the same three flags to `p_run`.
+
+Update `_build_inline_task()` so it merges:
+
+```python
+from models import expand_date_ranges
+
+dates = _collect_inline_values(args, "date", "dates")
+dates.extend(expand_date_ranges(getattr(args, "date_ranges", None)))
+```
+
+- [ ] **Step 4: Update inline-task routing to treat monitoring as explicit runtime intent**
+
+In `main.py`, extend `_should_use_inline_task()`:
+
+```python
+is_monitoring_without_date_preference = bool(getattr(args, "monitor", False))
+return has_inline_dates or has_inline_exact_times or is_launch_without_date_preference or is_monitoring_without_date_preference
+```
+
+- [ ] **Step 5: Thread monitoring kwargs through to the runtime**
+
+Update both `snipe_kwargs` blocks:
+
+```python
+monitor=getattr(args, "monitor", False),
+monitor_duration=getattr(args, "monitor_duration", 15.0),
+```
+
+- [ ] **Step 6: Run the targeted tests to verify they pass**
+
+Run: `venv/bin/pytest tests/test_main.py::test_parser_accepts_monitoring_flags_and_date_ranges tests/test_main.py::test_build_inline_task_expands_date_ranges -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add main.py tests/test_main.py
+git commit -m "feat: add monitoring and date range CLI flags"
+```
+
+### Task 3: Teach Recon To Look Ahead Across Multiple Months
+
+**Files:**
+- Modify: `recon.py`
+- Test: `tests/test_recon.py`
+
+- [ ] **Step 1: Write the failing recon helper tests**
+
+Add to `tests/test_recon.py`:
+
+```python
+from recon import _month_starts_for_lookahead
+
+
+def test_month_starts_for_lookahead_spans_future_months():
+    starts = _month_starts_for_lookahead("2026-04-18", lookahead_days=60)
+    assert starts == ["2026-04-01", "2026-05-01", "2026-06-01"]
+```
+
+- [ ] **Step 2: Run the targeted test to verify it fails**
+
+Run: `venv/bin/pytest tests/test_recon.py::test_month_starts_for_lookahead_spans_future_months -v`
+Expected: FAIL because `_month_starts_for_lookahead` does not exist.
+
+- [ ] **Step 3: Add month-window helpers**
+
+In `recon.py`, add:
+
+```python
+from datetime import date, timedelta
+
+
+def _month_starts_for_lookahead(today_iso: Optional[str] = None, lookahead_days: int = 60) -> List[str]:
+    today = datetime.strptime(today_iso, "%Y-%m-%d").date() if today_iso else datetime.now().date()
+    end = today + timedelta(days=lookahead_days)
+    cursor = date(today.year, today.month, 1)
+    starts: List[str] = []
+    while cursor <= end:
+        starts.append(cursor.isoformat())
+        if cursor.month == 12:
+            cursor = date(cursor.year + 1, 1, 1)
+        else:
+            cursor = date(cursor.year, cursor.month + 1, 1)
+    return starts
+```
+
+- [ ] **Step 4: Replace single-month recon with multi-month scanning**
+
+Refactor `_scrape_restaurant()` so it iterates the month starts returned by `_month_starts_for_lookahead()` and merges all discovered available dates into one result map:
+
+```python
+for month_start in _month_starts_for_lookahead(lookahead_days=lookahead_days):
+    url = (
+        f"https://www.exploretock.com/{slug}/search"
+        f"?date={month_start}&size={size}&time=19%3A00"
+    )
+```
+
+Only keep dates that are within the requested lookahead horizon.
+
+- [ ] **Step 5: Add a public lookahead argument to recon**
+
+Change the signature:
+
+```python
+async def recon(slug: str, size: str = DEFAULT_PARTY_SIZE, lookahead_days: int = 60) -> List[Task]:
+```
+
+Thread `lookahead_days` into `_scrape_restaurant()`.
+
+- [ ] **Step 6: Run the targeted tests**
+
+Run: `venv/bin/pytest tests/test_recon.py::test_month_starts_for_lookahead_spans_future_months -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add recon.py tests/test_recon.py
+git commit -m "feat: make recon scan forward across months"
+```
+
+### Task 4: Add Persistent Monitoring In The Runtime
+
+**Files:**
+- Modify: `sniper.py`
+- Test: `tests/test_sniper.py`
+
+- [ ] **Step 1: Write the failing monitoring tests**
+
+Add to `tests/test_sniper.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_launch_mode_does_not_exit_after_first_empty_new_release_diff():
+    from sniper import _monitor_newly_released_dates
+
+    snapshots = [
+        {"2026-05-01"},
+        {"2026-05-01"},
+        {"2026-05-01", "2026-05-21"},
+    ]
+
+    result = await _monitor_newly_released_dates(
+        before_dates=snapshots[0],
+        poll_snapshots=snapshots[1:],
+        requested_dates=["2026-05-21"],
+    )
+
+    assert result == ["2026-05-21"]
+```
+
+Use a small focused helper with injected snapshots rather than trying to unit-test full browser behavior directly.
+
+- [ ] **Step 2: Run the targeted test to verify it fails**
+
+Run: `venv/bin/pytest tests/test_sniper.py::test_launch_mode_does_not_exit_after_first_empty_new_release_diff -v`
+Expected: FAIL because `_monitor_newly_released_dates` does not exist.
+
+- [ ] **Step 3: Add a launch monitoring helper**
+
+In `sniper.py`, add a helper that repeatedly polls available dates until one of these happens:
+
+- newly released eligible dates are found
+- monitor duration expires
+
+Minimal shape:
+
+```python
+async def _monitor_newly_released_dates(
+    page: Page,
+    task: Task,
+    requested_dates: Optional[list],
+    interval: float,
+    deadline: Optional[float],
+) -> list:
+    baseline = await _capture_available_dates(page, task.url, task.size)
+    while True:
+        current = await _capture_available_dates(page, task.url, task.size)
+        eligible = _newly_released_dates(
+            before=baseline,
+            after=current,
+            requested_dates=requested_dates,
+        )
+        if eligible:
+            return eligible
+        if deadline is not None and asyncio.get_running_loop().time() >= deadline:
+            return []
+        await asyncio.sleep(interval)
+```
+
+- [ ] **Step 4: Add explicit monitoring parameters to the runtime**
+
+Update `snipe_task()` and `snipe_all()` signatures:
+
+```python
+async def snipe_task(..., monitor: bool = False, monitor_duration: float = 15.0, ...) -> Optional[dict]:
+```
+
+Use a deadline:
+
+```python
+deadline = asyncio.get_running_loop().time() + (monitor_duration * 60) if monitor or launch_newly_released_only else None
+```
+
+- [ ] **Step 5: Replace the one-shot launch diff with a monitoring loop**
+
+In the `launch_newly_released_only` branch, replace the single `before/after` comparison with repeated polling until either:
+
+- eligible dates appear
+- the monitoring deadline expires
+
+Do not `return None` after the first empty diff.
+
+- [ ] **Step 6: Support regular monitoring mode**
+
+When `monitor=True` and there are explicit or default target dates, keep worker tasks alive until:
+
+- a slot is secured
+- monitor duration expires
+
+Do not special-case monitoring as a one-shot recon result.
+
+- [ ] **Step 7: Run the targeted monitoring test**
+
+Run: `venv/bin/pytest tests/test_sniper.py::test_launch_mode_does_not_exit_after_first_empty_new_release_diff -v`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add sniper.py tests/test_sniper.py
+git commit -m "feat: add persistent launch and monitoring loops"
+```
+
+### Task 5: Wire Default Windows Into Run And Snipe
+
+**Files:**
+- Modify: `main.py`
+- Modify: `recon.py`
+- Test: `tests/test_main.py`
+
+- [ ] **Step 1: Write the failing default-window tests**
+
+Add to `tests/test_main.py`:
+
+```python
+def test_launch_mode_without_dates_uses_default_30_day_window():
+    args = argparse.Namespace(
+        slug="taneda",
+        size="1",
+        target=None,
+        date=[],
+        dates=None,
+        date_ranges=None,
+        exact_time=[],
+        exact_times=None,
+        release_at="11:00",
+        newly_released_only=True,
+        monitor=False,
+        monitor_duration=15.0,
+    )
+
+    task = _build_inline_task(args)
+
+    assert task.selectors == [Selector(dates=[])]
+```
+
+Keep the selector empty here and let the runtime expand it against the launch window.
+
+- [ ] **Step 2: Run the targeted test to verify behavior**
+
+Run: `venv/bin/pytest tests/test_main.py::test_launch_mode_without_dates_uses_default_30_day_window -v`
+Expected: PASS or near-pass, confirming the CLI keeps empty selectors for runtime-driven expansion.
+
+- [ ] **Step 3: Pass lookahead defaults into recon**
+
+In `_cmd_run()`, change:
+
+```python
+tasks = await recon(args.slug, size=args.size, lookahead_days=60)
+```
+
+In `_cmd_recon()`, change:
+
+```python
+tasks = await recon(args.slug, size=args.size, lookahead_days=60)
+```
+
+- [ ] **Step 4: Add default-window helpers for runtime-driven no-date launch**
+
+In `sniper.py`, when `launch_newly_released_only` is active and `_requested_dates_from_task(task)` is empty, compute requested dates from the next `30` days before filtering newly released dates.
+
+Use a helper like:
+
+```python
+def _default_launch_window_dates(days: int = 30) -> list:
+    today = datetime.now().date()
+    return [(today + timedelta(days=offset)).isoformat() for offset in range(days)]
+```
+
+- [ ] **Step 5: Run the focused tests**
+
+Run: `venv/bin/pytest tests/test_main.py tests/test_models.py tests/test_recon.py tests/test_sniper.py -q`
+Expected: PASS for the targeted unit suites.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add main.py recon.py sniper.py tests/test_main.py tests/test_models.py tests/test_recon.py tests/test_sniper.py
+git commit -m "fix: add forward windows for launch and regular monitoring"
+```
+
+### Task 6: Update Documentation
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Document the new flags**
+
+Add CLI docs for:
+
+```md
+--date-ranges "2026-05-07:2026-05-09,2026-05-21:2026-05-25"
+--monitor
+--monitor-duration 15
+```
+
+- [ ] **Step 2: Add launch monitoring examples**
+
+Add examples:
+
+```bash
+PLAYWRIGHT_HEADLESS=0 venv/bin/python main.py run taneda \
+  --size 1 \
+  --release-at 11:00 \
+  --newly-released-only \
+  --exact-times "5:15 PM,7:45 PM"
+```
+
+```bash
+PLAYWRIGHT_HEADLESS=0 venv/bin/python main.py run taneda \
+  --size 1 \
+  --monitor \
+  --interval 5
+```
+
+- [ ] **Step 3: Clarify default windows**
+
+Add text:
+
+```md
+- launch mode without dates targets the next 30 calendar days by default
+- regular recon and monitoring look ahead 60 calendar days by default
+```
+
+- [ ] **Step 4: Verify docs are readable**
+
+Run: `sed -n '1,260p' README.md`
+Expected: the new examples and defaults are visible and consistent with the CLI.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add monitoring and forward window examples"
+```
+
+### Task 7: Final Verification
+
+**Files:**
+- Modify: none
+
+- [ ] **Step 1: Run the full non-integration suite**
+
+Run: `venv/bin/pytest tests/ --ignore=tests/integration -q`
+Expected: PASS.
+
+- [ ] **Step 2: Run CLI help smoke checks**
+
+Run: `venv/bin/python main.py run --help`
+Expected: PASS and shows `--date-ranges`, `--monitor`, and `--monitor-duration`.
+
+Run: `venv/bin/python main.py snipe --help`
+Expected: PASS and shows the same new flags.
+
+- [ ] **Step 3: Run a live smoke check outside the sandbox**
+
+Run:
+
+```bash
+PLAYWRIGHT_HEADLESS=1 venv/bin/pytest tests/integration/test_smoke.py -q -s
+```
+
+Expected: PASS with a real Tock calendar rendering.
+
+- [ ] **Step 4: Run a live no-date monitoring dry-run outside the sandbox**
+
+Run:
+
+```bash
+PLAYWRIGHT_HEADLESS=0 venv/bin/python main.py run taneda \
+  --size 1 \
+  --release-at 11:00 \
+  --newly-released-only \
+  --exact-times "5:15 PM,7:45 PM" \
+  --monitor-duration 1 \
+  --dry-run
+```
+
+Expected: the process stays alive for the monitoring window instead of exiting after a single empty newly-released check.
+
+- [ ] **Step 5: Final commit if needed**
+
+```bash
+git status
+```
+
+If verification required code/doc changes:
+
+```bash
+git add README.md main.py recon.py sniper.py tests/test_main.py tests/test_models.py tests/test_recon.py tests/test_sniper.py
+git commit -m "test: verify monitoring and forward windows"
+```
+
+---
+
+## Self-Review
+
+- Spec coverage:
+  - forward recon window is covered in Task 3 and Task 5
+  - launch monitoring is covered in Task 4 and Task 7
+  - explicit monitoring mode is covered in Task 2 and Task 4
+  - date-range input is covered in Task 1 and Task 2
+  - documentation updates are covered in Task 6
+- Placeholder scan:
+  - no `TODO`, `TBD`, or “handle appropriately” placeholders remain
+- Type consistency:
+  - `monitor`, `monitor_duration`, and `date_ranges` are used consistently across CLI and runtime tasks

--- a/docs/superpowers/specs/2026-04-18-monitoring-and-forward-window-design.md
+++ b/docs/superpowers/specs/2026-04-18-monitoring-and-forward-window-design.md
@@ -1,0 +1,173 @@
+# Monitoring And Forward Window Design
+
+## Context
+
+The current sniper has two gaps that make it weak for live Tock drops and cancellation monitoring:
+
+- `recon` only inspects the current visible month, so regular `run` can miss target dates in the next month.
+- launch mode with `--newly-released-only` performs a single before/after diff at release time and exits if no newly released eligible dates are immediately actionable.
+
+The user wants a more battle-ready model:
+
+- launch mode should keep monitoring after release instead of giving up after one pass
+- regular mode should support long-running refresh behavior for sold-out dates that may return when holds expire
+- date targeting should support explicit date ranges and sensible defaults when the user does not provide dates
+- restaurant-specific knowledge like Taneda seatings and open days can live in the skill/preset layer, while the CLI core stays generic
+
+## Goals
+
+- Make forward-looking recon scan beyond the current visible month.
+- Add persistent monitoring behavior for launch and non-launch workflows.
+- Support compact date-range input in the CLI.
+- Keep exact-time targeting compatible with both launch and monitoring workflows.
+- Preserve a generic core runtime while allowing richer restaurant presets in the skill layer.
+
+## Non-Goals
+
+- Hardcode Taneda-specific business rules directly into the sniper core.
+- Build natural-language date parsing into the raw CLI.
+- Replace the current worker model with a separate orchestration service.
+
+## Recommended Approach
+
+Use one unified forward-looking targeting model:
+
+- both regular recon and monitoring flows use a configurable forward window instead of a single visible month
+- launch mode uses release-aware date discovery plus a post-release monitoring window
+- regular monitoring mode uses the same worker engine without release-time semantics
+- explicit dates and explicit date ranges override default windows
+
+This keeps one mental model across the product and avoids splitting launch and monitoring into separate engines.
+
+## Default Windows
+
+### Launch Mode
+
+- If the user provides exact dates or date ranges, those dates are the launch target set.
+- If the user does not provide dates, launch mode defaults to the next `30` calendar days.
+- If `--newly-released-only` is set, newly released dates are filtered inside that target window.
+- Launch monitoring should continue for `15` minutes by default after release.
+
+### Regular Mode
+
+- Regular recon and monitoring should look ahead `60` calendar days by default.
+- If explicit dates or date ranges are provided, those override the default forward window.
+- If monitoring is enabled, the sniper continues polling eligible dates instead of exiting after the initial recon snapshot.
+
+## CLI Input Model
+
+Keep the existing flags:
+
+- `--dates 2026-05-21,2026-05-22`
+- `--exact-times "5:15 PM,7:45 PM"`
+
+Add date-range support:
+
+- `--date-ranges "2026-05-07:2026-05-09,2026-05-21:2026-05-25"`
+
+The raw CLI should use ISO-like explicit syntax for reliability. The OpenClaw skill can accept more natural user input and translate it into CLI-safe `--dates` or `--date-ranges`.
+
+## Runtime Modes
+
+### Launch Mode
+
+Launch mode is triggered by `--release-at`.
+
+Behavior:
+
+- pre-warm browser state before release
+- compute the eligible date window from explicit dates, explicit date ranges, or the default next `30` days
+- if `--newly-released-only` is set, continue discovering newly released dates after release within the target window
+- once eligible dates appear, keep polling them for slot availability and hold returns
+- if `--exact-times` is provided, only those exact start times are actionable
+- if exact times are omitted, any matching slot on eligible dates is acceptable
+- default monitoring duration is `15` minutes unless explicitly overridden
+
+Launch mode should not stop after a single empty diff. It should keep checking until the monitoring duration expires or a slot is secured.
+
+### Regular Monitoring Mode
+
+Add an explicit monitoring mode, for example `--monitor`.
+
+Behavior:
+
+- no release-time semantics
+- find eligible dates in the explicit target set or the default forward recon window
+- keep polling those dates for the monitoring duration
+- if exact times are provided, only those start times are actionable
+- if no exact times are provided, any in-window slot is acceptable
+
+This is the mode for sold-out dates that may reappear from expired holds.
+
+## Recon Behavior
+
+`recon` should stop being “current visible month only.”
+
+Instead:
+
+- it should scan a forward window, defaulting to `60` days
+- it should collect all eligible visible dates inside that window
+- it should continue to sample time slots when possible
+- if time slots cannot be sampled, it can still fall back to the broad time window
+
+This change fixes the current Taneda issue where regular `run` only discovers a near-term visible date instead of the intended forward window.
+
+## Data Model Changes
+
+The current `Selector` shape can remain the canonical targeting model, but the CLI should be able to build selectors from:
+
+- explicit dates
+- expanded date ranges
+- empty dates plus a forward-window mode
+
+The runtime will need a way to represent:
+
+- monitoring enabled or disabled
+- monitoring duration
+- lookahead days for forward scanning
+
+These can live either in CLI/runtime kwargs or in a small config object without requiring a full architecture rewrite.
+
+## Skill Layer Responsibilities
+
+The OpenClaw skill or future presets can add restaurant-specific convenience such as:
+
+- inferring Taneda’s typical seating times like `5:15 PM` and `7:45 PM`
+- understanding open days like Wed–Sun
+- translating natural date-range requests into explicit CLI flags
+
+The core CLI should remain generic and should not encode restaurant-specific schedules.
+
+## Error Handling And UX
+
+Improve the CLI feedback for ambiguous commands:
+
+- exact times without dates and without launch/monitoring context should produce a clear usage error
+- launch mode with no date preferences should be interpreted as “use the default launch window,” not as zero workers
+- monitoring mode with no dates should be interpreted as “use the default monitoring window,” not as zero workers
+
+The logs should clearly distinguish:
+
+- no eligible dates found yet
+- eligible dates found but no matching slots yet
+- monitoring window expired
+
+## Testing Strategy
+
+Add coverage for:
+
+- date-range parsing into explicit dates
+- launch mode defaulting to next `30` days when no dates are supplied
+- regular monitoring defaulting to a forward window instead of a current-month-only recon snapshot
+- launch mode continuing past the first empty newly-released diff
+- monitoring mode continuing to poll until the monitoring duration expires
+- exact-time filtering remaining deterministic inside launch and monitoring loops
+
+## Summary
+
+The core product change is:
+
+- always look forward, not just at the current month
+- treat launch mode as a persistent release watcher, not a one-shot diff
+- add an explicit monitoring mode for cancellation and restock watching
+- keep restaurant intelligence in the skill layer, not the core runtime

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ import json
 import logging
 import sys
 
-from models import LaunchConfig, Selector, Task, Target
+from models import LaunchConfig, Selector, Task, Target, expand_date_ranges
 from recon import recon, save_config, load_config
 from sniper import snipe_all
 
@@ -87,12 +87,21 @@ def _collect_inline_values(args: argparse.Namespace, singular_name: str, plural_
 
 
 def _should_use_inline_task(args: argparse.Namespace) -> bool:
-    has_inline_dates = bool(getattr(args, "target", None) or args.date or getattr(args, "dates", None))
+    has_inline_dates = bool(
+        getattr(args, "target", None)
+        or args.date
+        or getattr(args, "dates", None)
+        or getattr(args, "date_ranges", None)
+    )
     has_inline_exact_times = bool(args.exact_time or getattr(args, "exact_times", None))
     is_launch_without_date_preference = bool(
         getattr(args, "release_at", None) and getattr(args, "newly_released_only", False)
     )
-    return has_inline_dates or has_inline_exact_times or is_launch_without_date_preference
+    return (
+        has_inline_dates
+        or has_inline_exact_times
+        or is_launch_without_date_preference
+    )
 
 
 def _build_inline_task(args: argparse.Namespace) -> Task:
@@ -109,6 +118,7 @@ def _build_inline_task(args: argparse.Namespace) -> Task:
         size = target_args[0][3]
     else:
         dates = _collect_inline_values(args, "date", "dates")
+        dates.extend(expand_date_ranges(getattr(args, "date_ranges", None)))
         exact_times = _collect_inline_values(args, "exact_time", "exact_times")
         selectors = [
             Selector(
@@ -128,6 +138,14 @@ def _build_inline_task(args: argparse.Namespace) -> Task:
     return Task(url=args.slug, size=size, selectors=selectors, launch=launch)
 
 
+def _build_inline_task_or_exit(args: argparse.Namespace) -> Task:
+    try:
+        return _build_inline_task(args)
+    except ValueError as exc:
+        log.error("Invalid --date-ranges value: %s", exc)
+        sys.exit(2)
+
+
 # ── Subcommand handlers ───────────────────────────────────────────────────────
 
 async def _cmd_recon(args: argparse.Namespace) -> None:
@@ -142,14 +160,22 @@ async def _cmd_recon(args: argparse.Namespace) -> None:
         print(json.dumps([t.to_dict() for t in tasks], indent=2))
 
 
+def _exit_if_monitoring_not_supported(args: argparse.Namespace) -> None:
+    if getattr(args, "monitor", False):
+        log.error("--monitor is not supported yet; this will be enabled when runtime monitoring lands.")
+        sys.exit(2)
+
+
 async def _cmd_snipe(args: argparse.Namespace) -> None:
+    _exit_if_monitoring_not_supported(args)
+
     if args.config:
         tasks = load_config(args.config)
     elif _should_use_inline_task(args):
         if not args.slug:
             log.error("Inline targeting requires a restaurant slug as positional argument")
             sys.exit(2)
-        tasks = [_build_inline_task(args)]
+        tasks = [_build_inline_task_or_exit(args)]
     else:
         log.error(
             "Provide --config FILE, --target ..., at least one --date/--dates, "
@@ -177,8 +203,10 @@ async def _cmd_snipe(args: argparse.Namespace) -> None:
 
 
 async def _cmd_run(args: argparse.Namespace) -> None:
+    _exit_if_monitoring_not_supported(args)
+
     if _should_use_inline_task(args):
-        tasks = [_build_inline_task(args)]
+        tasks = [_build_inline_task_or_exit(args)]
     else:
         tasks = await recon(args.slug, size=args.size)
         if not tasks:
@@ -234,6 +262,8 @@ def _build_parser() -> argparse.ArgumentParser:
                          help="Exact reservation start time, e.g. '5:15 PM' (repeatable)")
     p_snipe.add_argument("--dates",
                          help="Comma-separated target dates, e.g. '2026-05-27,2026-05-28'")
+    p_snipe.add_argument("--date-ranges",
+                         help="Comma-separated date ranges, e.g. '2026-05-07:2026-05-09,2026-05-21:2026-05-25'")
     p_snipe.add_argument("--exact-times",
                          help="Comma-separated exact times, e.g. '5:15 PM,7:45 PM'")
     p_snipe.add_argument("--dry-run", action="store_true", help="Find slots but don't click")
@@ -241,6 +271,10 @@ def _build_parser() -> argparse.ArgumentParser:
                          help="Poll interval in seconds (default: 30)")
     p_snipe.add_argument("--max-duration", type=float, default=0, metavar="MINUTES",
                          help="Stop after this many minutes (0 = unlimited)")
+    p_snipe.add_argument("--monitor", action="store_true",
+                         help="Keep polling for cancellations/restocks instead of exiting after one pass")
+    p_snipe.add_argument("--monitor-duration", type=float, default=15.0, metavar="MINUTES",
+                         help="Monitoring duration in minutes (default: 15)")
     p_snipe.add_argument("--release-at", metavar="HH:MM",
                          help="Start sniping at this time of day")
     p_snipe.add_argument("--cdp-url",
@@ -268,6 +302,8 @@ def _build_parser() -> argparse.ArgumentParser:
                        help="Exact reservation start time, e.g. '5:15 PM' (repeatable)")
     p_run.add_argument("--dates",
                        help="Comma-separated target dates, e.g. '2026-05-27,2026-05-28'")
+    p_run.add_argument("--date-ranges",
+                      help="Comma-separated date ranges, e.g. '2026-05-07:2026-05-09,2026-05-21:2026-05-25'")
     p_run.add_argument("--exact-times",
                        help="Comma-separated exact times, e.g. '5:15 PM,7:45 PM'")
     p_run.add_argument("--dry-run", action="store_true", help="Find slots but don't click")
@@ -276,6 +312,10 @@ def _build_parser() -> argparse.ArgumentParser:
                        help="Poll interval in seconds (default: 30)")
     p_run.add_argument("--max-duration", type=float, default=0, metavar="MINUTES",
                        help="Stop after this many minutes (0 = unlimited)")
+    p_run.add_argument("--monitor", action="store_true",
+                      help="Keep polling for cancellations/restocks instead of exiting after one pass")
+    p_run.add_argument("--monitor-duration", type=float, default=15.0, metavar="MINUTES",
+                      help="Monitoring duration in minutes (default: 15)")
     p_run.add_argument("--release-at", metavar="HH:MM",
                        help="Start sniping at this time of day")
     p_run.add_argument("--cdp-url",

--- a/main.py
+++ b/main.py
@@ -86,6 +86,15 @@ def _collect_inline_values(args: argparse.Namespace, singular_name: str, plural_
     return values
 
 
+def _should_use_inline_task(args: argparse.Namespace) -> bool:
+    has_inline_dates = bool(getattr(args, "target", None) or args.date or getattr(args, "dates", None))
+    has_inline_exact_times = bool(args.exact_time or getattr(args, "exact_times", None))
+    is_launch_without_date_preference = bool(
+        getattr(args, "release_at", None) and getattr(args, "newly_released_only", False)
+    )
+    return has_inline_dates or has_inline_exact_times or is_launch_without_date_preference
+
+
 def _build_inline_task(args: argparse.Namespace) -> Task:
     target_args = getattr(args, "target", None)
     if target_args:
@@ -136,13 +145,16 @@ async def _cmd_recon(args: argparse.Namespace) -> None:
 async def _cmd_snipe(args: argparse.Namespace) -> None:
     if args.config:
         tasks = load_config(args.config)
-    elif args.target or args.date or getattr(args, "dates", None):
+    elif _should_use_inline_task(args):
         if not args.slug:
             log.error("Inline targeting requires a restaurant slug as positional argument")
             sys.exit(2)
         tasks = [_build_inline_task(args)]
     else:
-        log.error("Provide --config FILE, --target ..., or at least one --date/--dates")
+        log.error(
+            "Provide --config FILE, --target ..., at least one --date/--dates, "
+            "or launch mode with --release-at and --newly-released-only"
+        )
         sys.exit(2)
 
     if not tasks:
@@ -165,7 +177,7 @@ async def _cmd_snipe(args: argparse.Namespace) -> None:
 
 
 async def _cmd_run(args: argparse.Namespace) -> None:
-    if args.date or args.exact_time or getattr(args, "dates", None) or getattr(args, "exact_times", None):
+    if _should_use_inline_task(args):
         tasks = [_build_inline_task(args)]
     else:
         tasks = await recon(args.slug, size=args.size)

--- a/main.py
+++ b/main.py
@@ -28,6 +28,8 @@ from sniper import snipe_all
 
 # ── Logging ───────────────────────────────────────────────────────────────────
 
+DEFAULT_RECON_LOOKAHEAD_DAYS = 60
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(name)-12s] %(levelname)s: %(message)s",
@@ -149,7 +151,7 @@ def _build_inline_task_or_exit(args: argparse.Namespace) -> Task:
 # ── Subcommand handlers ───────────────────────────────────────────────────────
 
 async def _cmd_recon(args: argparse.Namespace) -> None:
-    tasks = await recon(args.slug, size=args.size)
+    tasks = await recon(args.slug, size=args.size, lookahead_days=DEFAULT_RECON_LOOKAHEAD_DAYS)
     if not tasks:
         log.warning("No availability found for '%s'.", args.slug)
         sys.exit(1)
@@ -160,15 +162,7 @@ async def _cmd_recon(args: argparse.Namespace) -> None:
         print(json.dumps([t.to_dict() for t in tasks], indent=2))
 
 
-def _exit_if_monitoring_not_supported(args: argparse.Namespace) -> None:
-    if getattr(args, "monitor", False):
-        log.error("--monitor is not supported yet; this will be enabled when runtime monitoring lands.")
-        sys.exit(2)
-
-
 async def _cmd_snipe(args: argparse.Namespace) -> None:
-    _exit_if_monitoring_not_supported(args)
-
     if args.config:
         tasks = load_config(args.config)
     elif _should_use_inline_task(args):
@@ -192,6 +186,8 @@ async def _cmd_snipe(args: argparse.Namespace) -> None:
         interval=args.interval,
         max_duration=args.max_duration,
         release_at=getattr(args, "release_at", None),
+        monitor=getattr(args, "monitor", False),
+        monitor_duration=getattr(args, "monitor_duration", 15.0),
         cdp_url=getattr(args, "cdp_url", None),
         timezone=getattr(args, "timezone", None),
         cookies_file=getattr(args, "cookies_file", None),
@@ -203,12 +199,10 @@ async def _cmd_snipe(args: argparse.Namespace) -> None:
 
 
 async def _cmd_run(args: argparse.Namespace) -> None:
-    _exit_if_monitoring_not_supported(args)
-
     if _should_use_inline_task(args):
         tasks = [_build_inline_task_or_exit(args)]
     else:
-        tasks = await recon(args.slug, size=args.size)
+        tasks = await recon(args.slug, size=args.size, lookahead_days=DEFAULT_RECON_LOOKAHEAD_DAYS)
         if not tasks:
             log.warning("Recon found no availability for '%s'. Nothing to snipe.", args.slug)
             sys.exit(1)
@@ -219,6 +213,8 @@ async def _cmd_run(args: argparse.Namespace) -> None:
         interval=args.interval,
         max_duration=args.max_duration,
         release_at=getattr(args, "release_at", None),
+        monitor=getattr(args, "monitor", False),
+        monitor_duration=getattr(args, "monitor_duration", 15.0),
         cdp_url=getattr(args, "cdp_url", None),
         timezone=getattr(args, "timezone", None),
         cookies_file=getattr(args, "cookies_file", None),

--- a/models.py
+++ b/models.py
@@ -2,10 +2,30 @@
 
 import json
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import List, Optional
 
 RESERVATION_TIME_FORMAT = "%I:%M %p"
+
+
+def expand_date_ranges(raw: Optional[str]) -> List[str]:
+    if not raw:
+        return []
+
+    expanded: List[str] = []
+    for part in [piece.strip() for piece in raw.split(",") if piece.strip()]:
+        start_s, end_s = [token.strip() for token in part.split(":", 1)]
+        start = datetime.strptime(start_s, "%Y-%m-%d").date()
+        end = datetime.strptime(end_s, "%Y-%m-%d").date()
+        if end < start:
+            raise ValueError(f"Invalid date range: {part}")
+
+        cursor = start
+        while cursor <= end:
+            expanded.append(cursor.isoformat())
+            cursor += timedelta(days=1)
+
+    return expanded
 
 
 @dataclass

--- a/recon.py
+++ b/recon.py
@@ -18,7 +18,7 @@ import json
 import logging
 import os
 import sys
-from datetime import datetime
+from datetime import date, datetime, timedelta
 from typing import Dict, List, Optional, Tuple
 
 from playwright.async_api import async_playwright, Browser, BrowserContext, Page, TimeoutError as PWTimeout
@@ -50,22 +50,59 @@ async def _new_stealth_page(context: BrowserContext) -> Page:
     return page
 
 
+def _lookahead_bounds(today_iso: Optional[str] = None, lookahead_days: int = 60) -> Tuple[date, date]:
+    today = datetime.strptime(today_iso, "%Y-%m-%d").date() if today_iso else datetime.now().date()
+    return today, today + timedelta(days=lookahead_days)
+
+
+def _month_starts_for_lookahead(today_iso: Optional[str] = None, lookahead_days: int = 60) -> List[str]:
+    today, end = _lookahead_bounds(today_iso=today_iso, lookahead_days=lookahead_days)
+    cursor = date(today.year, today.month, 1)
+    starts: List[str] = []
+    while cursor <= end:
+        starts.append(cursor.isoformat())
+        if cursor.month == 12:
+            cursor = date(cursor.year + 1, 1, 1)
+        else:
+            cursor = date(cursor.year, cursor.month + 1, 1)
+    return starts
+
+
+def _date_is_within_lookahead(date_str: str, start: date, end: date) -> bool:
+    try:
+        candidate = datetime.strptime(date_str, "%Y-%m-%d").date()
+    except ValueError:
+        return False
+    return start <= candidate <= end
+
+
+def _merge_time_slots(existing_slots: List[str], new_slots: List[str]) -> List[str]:
+    if not existing_slots:
+        return list(new_slots)
+    if not new_slots:
+        return list(existing_slots)
+
+    merged: List[str] = []
+    for slot in [*existing_slots, *new_slots]:
+        if slot not in merged:
+            merged.append(slot)
+    return merged
+
+
 # ── Core scraping ─────────────────────────────────────────────────────────────
 
-async def _scrape_restaurant(slug: str, size: str) -> Dict[str, dict]:
+async def _scrape_restaurant(slug: str, size: str, lookahead_days: int = 60) -> Dict[str, dict]:
     """
     Open the Tock search page for *slug* and extract available dates.
     Returns a dict keyed by ISO date string ("YYYY-MM-DD"):
         { "2026-03-15": { "time_slots": ["5:00 PM", ...] }, ... }
     """
-    month_n = f"{datetime.now().month:02d}"
-    year    = str(datetime.now().year)
-    url     = (
-        f"https://www.exploretock.com/{slug}/search"
-        f"?date={year}-{month_n}-01&size={size}&time=19%3A00"
-    )
-
     result: Dict[str, dict] = {}
+    lookahead_start, lookahead_end = _lookahead_bounds(lookahead_days=lookahead_days)
+    month_starts = _month_starts_for_lookahead(
+        today_iso=lookahead_start.isoformat(),
+        lookahead_days=lookahead_days,
+    )
 
     async with async_playwright() as p:
         _launch_kwargs: dict = {"headless": HEADLESS, "args": ["--disable-blink-features=AutomationControlled"]}
@@ -82,78 +119,88 @@ async def _scrape_restaurant(slug: str, size: str) -> Dict[str, dict]:
         page = await _new_stealth_page(context)
 
         try:
-            log.info("[recon] Loading %s", url)
-            await page.goto(url, wait_until="domcontentloaded", timeout=PAGE_LOAD_TIMEOUT_MS)
-
-            # Try __NEXT_DATA__ extraction as supplementary data source
-            nd_slots = None
-            try:
-                next_data = await page.evaluate(NEXT_DATA_JS)
-                nd_slots = _parse_next_data_json(next_data)
-                if nd_slots:
-                    log.info("[recon] __NEXT_DATA__ found %d slot(s)", len(nd_slots))
-            except Exception:
-                pass
-
-            # Wait for calendar + extra settle time for React to render day buttons
-            try:
-                await page.wait_for_selector("div.ConsumerCalendar-month", timeout=PAGE_LOAD_TIMEOUT_MS)
-                await page.wait_for_timeout(2000)
-            except PWTimeout:
-                log.error(
-                    "[recon] Calendar not found for '%s'. "
-                    "Is this a valid Tock slug? Cloudflare may be blocking.",
-                    slug,
+            for month_start in month_starts:
+                url = (
+                    f"https://www.exploretock.com/{slug}/search"
+                    f"?date={month_start}&size={size}&time=19%3A00"
                 )
-                return result
+                log.info("[recon] Loading %s", url)
+                await page.goto(url, wait_until="domcontentloaded", timeout=PAGE_LOAD_TIMEOUT_MS)
 
-            # ── Collect all available days via aria-label ("YYYY-MM-DD") ─────
-            # Each available day button carries data-testid="consumer-calendar-day"
-            # and aria-disabled="false".
-            day_btns = await page.query_selector_all(
-                "button[data-testid='consumer-calendar-day'][aria-disabled='false']"
-            )
-            log.info("[recon] Found %d available day button(s)", len(day_btns))
-
-            # Group by date string; remember first button per date for time-slot sampling.
-            from collections import defaultdict
-            dates: Dict[str, dict] = {}   # date_str → {first_btn}
-            for btn in day_btns:
-                label = await btn.get_attribute("aria-label")  # "2026-03-05"
-                if not label or len(label) != 10:
-                    continue
-                if label not in dates:
-                    dates[label] = {"first_btn": btn}
-
-            for date_str, data in dates.items():
-                first_btn = data["first_btn"]
-                log.info("[recon] Available date: %s", date_str)
-
-                # ── Sample time slots by clicking the available day ──────────
-                time_slots: List[str] = []
+                # Try __NEXT_DATA__ extraction as supplementary data source
+                nd_slots = None
                 try:
-                    await first_btn.click()
-                    await page.wait_for_selector(
-                        "[data-testid='search-result']",
-                        timeout=8_000,
-                    )
-                    cards = await page.query_selector_all("[data-testid='search-result']")
-                    for card in cards:
-                        time_el = await card.query_selector("[data-testid='search-result-time']")
-                        if time_el:
-                            time_slots.append((await time_el.inner_text()).strip())
-                    log.info("[recon] %s: time slots found: %s", date_str, time_slots)
+                    next_data = await page.evaluate(NEXT_DATA_JS)
+                    nd_slots = _parse_next_data_json(next_data)
+                    if nd_slots:
+                        log.info("[recon] __NEXT_DATA__ found %d slot(s)", len(nd_slots))
+                except Exception:
+                    pass
+
+                # Wait for calendar + extra settle time for React to render day buttons
+                try:
+                    await page.wait_for_selector("div.ConsumerCalendar-month", timeout=PAGE_LOAD_TIMEOUT_MS)
+                    await page.wait_for_timeout(2000)
                 except PWTimeout:
-                    log.debug("[recon] No search-result cards loaded for %s", date_str)
-                except Exception as e:
-                    log.debug("[recon] Error fetching time slots: %s", e)
+                    log.error(
+                        "[recon] Calendar not found for '%s'. "
+                        "Is this a valid Tock slug? Cloudflare may be blocking.",
+                        slug,
+                    )
+                    return result
 
-                # Fall back to __NEXT_DATA__ slots if DOM scraping yielded nothing
-                if not time_slots and nd_slots:
-                    log.info("[recon] %s: using __NEXT_DATA__ slots as fallback", date_str)
-                    time_slots = list(nd_slots)
+                # ── Collect all available days via aria-label ("YYYY-MM-DD") ─────
+                # Each available day button carries data-testid="consumer-calendar-day"
+                # and aria-disabled="false".
+                day_btns = await page.query_selector_all(
+                    "button[data-testid='consumer-calendar-day'][aria-disabled='false']"
+                )
 
-                result[date_str] = {"time_slots": time_slots}
+                # Group by date string; remember first button per date for time-slot sampling.
+                dates: Dict[str, dict] = {}
+                for btn in day_btns:
+                    label = await btn.get_attribute("aria-label")  # "2026-03-05"
+                    if not label or len(label) != 10:
+                        continue
+                    if not _date_is_within_lookahead(label, lookahead_start, lookahead_end):
+                        continue
+                    if label not in dates:
+                        dates[label] = {"first_btn": btn}
+
+                log.info("[recon] Found %d available day button(s)", len(dates))
+
+                for date_str, data in sorted(dates.items()):
+                    first_btn = data["first_btn"]
+                    log.info("[recon] Available date: %s", date_str)
+
+                    # ── Sample time slots by clicking the available day ──────────
+                    time_slots: List[str] = []
+                    try:
+                        await first_btn.click()
+                        await page.wait_for_selector(
+                            "[data-testid='search-result']",
+                            timeout=8_000,
+                        )
+                        cards = await page.query_selector_all("[data-testid='search-result']")
+                        for card in cards:
+                            time_el = await card.query_selector("[data-testid='search-result-time']")
+                            if time_el:
+                                time_slots.append((await time_el.inner_text()).strip())
+                        log.info("[recon] %s: time slots found: %s", date_str, time_slots)
+                    except PWTimeout:
+                        log.debug("[recon] No search-result cards loaded for %s", date_str)
+                    except Exception as e:
+                        log.debug("[recon] Error fetching time slots: %s", e)
+
+                    # Fall back to __NEXT_DATA__ slots if DOM scraping yielded nothing
+                    if not time_slots and nd_slots:
+                        log.info("[recon] %s: using __NEXT_DATA__ slots as fallback", date_str)
+                        time_slots = list(nd_slots)
+
+                    existing_slots = result.get(date_str, {}).get("time_slots", [])
+                    result[date_str] = {
+                        "time_slots": _merge_time_slots(existing_slots, time_slots)
+                    }
 
         finally:
             await browser.close()
@@ -277,13 +324,13 @@ Rules:
 
 # ── Public API ────────────────────────────────────────────────────────────────
 
-async def recon(slug: str, size: str = DEFAULT_PARTY_SIZE) -> List[Task]:
+async def recon(slug: str, size: str = DEFAULT_PARTY_SIZE, lookahead_days: int = 60) -> List[Task]:
     """
     Visit the Tock page for *slug* and return a list of Task configs
     representing all available dates within the acceptable time window.
     """
     log.info("[recon] Starting for %s (party of %s)", slug, size)
-    availability = await _scrape_restaurant(slug, size)
+    availability = await _scrape_restaurant(slug, size, lookahead_days=lookahead_days)
 
     if not availability:
         log.warning("[recon] No availability found for %s", slug)

--- a/sniper.py
+++ b/sniper.py
@@ -215,6 +215,117 @@ def _newly_released_dates(
     return eligible
 
 
+def _remaining_deadline_seconds(deadline: Optional[float]) -> Optional[float]:
+    if deadline is None:
+        return None
+    return max(0.0, deadline - asyncio.get_running_loop().time())
+
+
+def _monitor_timeout_message(
+    max_duration: float,
+    deadline: Optional[float],
+) -> tuple[Optional[float], Optional[str]]:
+    deadline_timeout = _remaining_deadline_seconds(deadline)
+    max_timeout = max_duration * 60 if max_duration > 0 else None
+
+    timeout_options = [timeout for timeout in (deadline_timeout, max_timeout) if timeout is not None]
+    if not timeout_options:
+        return None, None
+
+    timeout_seconds = min(timeout_options)
+    if max_timeout is not None and timeout_seconds == max_timeout:
+        return timeout_seconds, f"max-duration {max_duration:.0f}min reached"
+    if deadline is not None:
+        return timeout_seconds, "monitoring window reached"
+    return timeout_seconds, None
+
+
+async def _wait_for_worker_outcome(
+    task_url: str,
+    found_event: asyncio.Event,
+    worker_tasks: list,
+    timeout_seconds: Optional[float],
+    timeout_message: Optional[str],
+) -> None:
+    if not worker_tasks:
+        return
+
+    loop = asyncio.get_running_loop()
+    deadline = None if timeout_seconds is None else (loop.time() + timeout_seconds)
+    event_task = asyncio.create_task(found_event.wait())
+
+    try:
+        while True:
+            if all(worker_task.done() for worker_task in worker_tasks):
+                await asyncio.gather(*worker_tasks, return_exceptions=True)
+                return
+
+            pending = {worker_task for worker_task in worker_tasks if not worker_task.done()}
+            if not event_task.done():
+                pending.add(event_task)
+
+            wait_timeout = None
+            if deadline is not None:
+                wait_timeout = max(0.0, deadline - loop.time())
+                if wait_timeout <= 0:
+                    if timeout_message:
+                        log.info("[%s] %s — stopping.", task_url, timeout_message)
+                    await _stop_worker_tasks(task_url, found_event, worker_tasks)
+                    return
+
+            done, _ = await asyncio.wait(
+                pending,
+                timeout=wait_timeout,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if not done:
+                if timeout_message:
+                    log.info("[%s] %s — stopping.", task_url, timeout_message)
+                await _stop_worker_tasks(task_url, found_event, worker_tasks)
+                return
+
+            if event_task in done:
+                await _stop_worker_tasks(task_url, found_event, worker_tasks)
+                return
+    finally:
+        if not event_task.done():
+            event_task.cancel()
+            await asyncio.gather(event_task, return_exceptions=True)
+
+
+async def _monitor_newly_released_dates(
+    page: Page,
+    task: Task,
+    requested_dates: Optional[list],
+    interval: float,
+    deadline: Optional[float],
+    baseline_dates: Optional[set] = None,
+) -> list:
+    if baseline_dates is None:
+        baseline = set(await _capture_available_dates(page, task.url, task.size))
+    else:
+        baseline = set(baseline_dates)
+
+    while True:
+        current = await _capture_available_dates(page, task.url, task.size)
+        eligible = _newly_released_dates(
+            before=baseline,
+            after=current,
+            requested_dates=requested_dates,
+        )
+        if eligible:
+            return eligible
+
+        remaining = _remaining_deadline_seconds(deadline)
+        if remaining is not None and remaining <= 0:
+            return []
+
+        sleep_for = max(0.5, interval)
+        if remaining is not None:
+            sleep_for = min(sleep_for, remaining)
+        await asyncio.sleep(sleep_for)
+
+
 async def _open_browser_context(playwright, cdp_url: Optional[str] = None):
     """Open a browser/context pair and return ownership flags for cleanup."""
     if cdp_url:
@@ -688,6 +799,8 @@ async def snipe_task(
     dry_run: bool = False,
     interval: float = 30.0,
     max_duration: float = 0,
+    monitor: bool = False,
+    monitor_duration: float = 15.0,
     release_at=None,
     cdp_url: str = None,
     timezone: str = None,
@@ -720,6 +833,7 @@ async def snipe_task(
             await _interactive_login(context, PAGE_LOAD_TIMEOUT)
 
         resolved_task = task
+        monitor_deadline: Optional[float] = None
         if effective_release_at and launch_newly_released_only:
             scout = await context.new_page()
             opened_pages.append(scout)
@@ -727,17 +841,20 @@ async def snipe_task(
             try:
                 before_dates = await _capture_available_dates(scout, task.url, task.size)
                 await _wait_for_release(effective_release_at, timezone=timezone)
-                after_dates = await _capture_available_dates(scout, task.url, task.size)
+                monitor_deadline = asyncio.get_running_loop().time() + (monitor_duration * 60)
+                eligible_dates = await _monitor_newly_released_dates(
+                    scout,
+                    task,
+                    requested_dates=_requested_dates_from_task(task),
+                    interval=interval,
+                    deadline=monitor_deadline,
+                    baseline_dates=before_dates,
+                )
             finally:
                 await scout.close()
 
-            eligible_dates = _newly_released_dates(
-                before=before_dates,
-                after=after_dates,
-                requested_dates=_requested_dates_from_task(task),
-            )
             if not eligible_dates:
-                log.info("[%s] No newly released eligible dates found.", task.url)
+                log.info("[%s] No newly released eligible dates found before monitoring window expired.", task.url)
                 await _cleanup_browser_session(
                     browser,
                     context,
@@ -747,6 +864,8 @@ async def snipe_task(
                 )
                 return None
             resolved_task = task.filter_dates(eligible_dates)
+        elif monitor:
+            monitor_deadline = asyncio.get_running_loop().time() + (monitor_duration * 60)
 
         # Open one tab per target
         workers: List[DayWorker] = []
@@ -776,15 +895,14 @@ async def snipe_task(
 
         # Run all workers concurrently
         worker_tasks = [asyncio.create_task(w.run()) for w in workers]
-        if max_duration > 0:
-            done, pending = await asyncio.wait(worker_tasks, timeout=max_duration * 60)
-            if pending:
-                log.info("[%s] max-duration %.0fmin reached — stopping.", task.url, max_duration)
-                await _stop_worker_tasks(task.url, found_event, worker_tasks)
-            else:
-                await asyncio.gather(*worker_tasks, return_exceptions=True)
-        else:
-            await asyncio.gather(*worker_tasks, return_exceptions=True)
+        timeout_seconds, timeout_message = _monitor_timeout_message(max_duration, monitor_deadline)
+        await _wait_for_worker_outcome(
+            task.url,
+            found_event,
+            worker_tasks,
+            timeout_seconds=timeout_seconds,
+            timeout_message=timeout_message,
+        )
 
         await _cleanup_browser_session(
             browser,
@@ -810,14 +928,27 @@ async def snipe_task(
     }
 
 
-async def snipe_all(tasks: List[Task], **kwargs) -> List[dict]:
+async def snipe_all(
+    tasks: List[Task],
+    monitor: bool = False,
+    monitor_duration: float = 15.0,
+    **kwargs,
+) -> List[dict]:
     """Run multiple restaurant tasks concurrently, returning a list of result dicts."""
     log.info(
         "Sniping %d restaurant(s) | %d total target-workers",
         len(tasks), sum(len(t.targets) for t in tasks),
     )
     raw = await asyncio.gather(
-        *[snipe_task(t, **kwargs) for t in tasks],
+        *[
+            snipe_task(
+                t,
+                monitor=monitor,
+                monitor_duration=monitor_duration,
+                **kwargs,
+            )
+            for t in tasks
+        ],
         return_exceptions=True,
     )
     results = []

--- a/sniper.py
+++ b/sniper.py
@@ -26,7 +26,7 @@ import os
 import random
 import re
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 from typing import List, Optional
 
@@ -213,6 +213,11 @@ def _newly_released_dates(
         allowed = set(requested_dates)
         eligible = [date for date in eligible if date in allowed]
     return eligible
+
+
+def _default_launch_window_dates(days: int = 30) -> list:
+    today = datetime.now().date()
+    return [(today + timedelta(days=offset)).isoformat() for offset in range(days)]
 
 
 def _remaining_deadline_seconds(deadline: Optional[float]) -> Optional[float]:
@@ -838,6 +843,7 @@ async def snipe_task(
             scout = await context.new_page()
             opened_pages.append(scout)
             await _apply_stealth(scout)
+            requested_dates = _requested_dates_from_task(task) or _default_launch_window_dates()
             try:
                 before_dates = await _capture_available_dates(scout, task.url, task.size)
                 await _wait_for_release(effective_release_at, timezone=timezone)
@@ -845,7 +851,7 @@ async def snipe_task(
                 eligible_dates = await _monitor_newly_released_dates(
                     scout,
                     task,
-                    requested_dates=_requested_dates_from_task(task),
+                    requested_dates=requested_dates,
                     interval=interval,
                     deadline=monitor_deadline,
                     baseline_dates=before_dates,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -157,7 +157,7 @@ def test_build_inline_task_expands_date_ranges():
     ]
 
 
-def test_monitoring_mode_does_not_use_inline_task_without_runtime_support():
+def test_monitoring_mode_without_dates_still_uses_recon_path():
     parser = _build_parser()
 
     args = parser.parse_args([
@@ -182,29 +182,86 @@ def test_date_ranges_alone_use_inline_task_mode():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("command", "argv"),
-    [
-        ("run", ["run", "taneda", "--monitor"]),
-        ("snipe", ["snipe", "taneda", "--monitor"]),
-    ],
-)
-async def test_monitor_mode_fails_fast_until_runtime_support(command, argv, monkeypatch, caplog):
+async def test_cmd_run_forwards_monitoring_kwargs_and_lookahead(monkeypatch):
     parser = _build_parser()
-    args = parser.parse_args(argv)
-    cmd = getattr(main_module, f"_cmd_{command}")
+    args = parser.parse_args([
+        "run",
+        "taneda",
+        "--size", "1",
+        "--monitor",
+        "--monitor-duration", "20",
+    ])
+    captured = {}
 
-    async def fail_if_called(*_args, **_kwargs):
-        raise AssertionError("snipe_all should not be called when monitor mode is unsupported")
+    async def fake_recon(slug, size, lookahead_days):
+        captured["recon"] = (slug, size, lookahead_days)
+        return [main_module.Task(url=slug, size=size, selectors=[main_module.Selector(dates=["2026-05-21"])])]
 
-    monkeypatch.setattr(main_module, "snipe_all", fail_if_called)
+    async def fake_snipe_all(tasks, **kwargs):
+        captured["tasks"] = tasks
+        captured["kwargs"] = kwargs
+        return []
 
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(SystemExit) as excinfo:
-            await cmd(args)
+    monkeypatch.setattr(main_module, "recon", fake_recon)
+    monkeypatch.setattr(main_module, "snipe_all", fake_snipe_all)
+    monkeypatch.setattr(main_module, "_print_results", lambda results, json_mode: None)
 
-    assert excinfo.value.code == 2
-    assert "--monitor is not supported yet" in caplog.text
+    await main_module._cmd_run(args)
+
+    assert captured["recon"] == ("taneda", "1", main_module.DEFAULT_RECON_LOOKAHEAD_DAYS)
+    assert captured["kwargs"]["monitor"] is True
+    assert captured["kwargs"]["monitor_duration"] == 20
+
+
+@pytest.mark.asyncio
+async def test_cmd_snipe_forwards_monitoring_kwargs_for_inline_targets(monkeypatch):
+    parser = _build_parser()
+    args = parser.parse_args([
+        "snipe",
+        "taneda",
+        "--date", "2026-05-21",
+        "--monitor",
+        "--monitor-duration", "10",
+    ])
+    captured = {}
+
+    async def fake_snipe_all(tasks, **kwargs):
+        captured["tasks"] = tasks
+        captured["kwargs"] = kwargs
+        return []
+
+    monkeypatch.setattr(main_module, "snipe_all", fake_snipe_all)
+    monkeypatch.setattr(main_module, "_print_results", lambda results, json_mode: None)
+
+    await main_module._cmd_snipe(args)
+
+    assert [selector.to_dict() for selector in captured["tasks"][0].selectors] == [
+        {"dates": ["2026-05-21"]}
+    ]
+    assert captured["kwargs"]["monitor"] is True
+    assert captured["kwargs"]["monitor_duration"] == 10
+
+
+@pytest.mark.asyncio
+async def test_cmd_recon_uses_default_lookahead_days(monkeypatch, capsys):
+    parser = _build_parser()
+    args = parser.parse_args([
+        "recon",
+        "taneda",
+        "--size", "1",
+    ])
+    captured = {}
+
+    async def fake_recon(slug, size, lookahead_days):
+        captured["args"] = (slug, size, lookahead_days)
+        return [main_module.Task(url=slug, size=size, selectors=[main_module.Selector(dates=["2026-05-21"])])]
+
+    monkeypatch.setattr(main_module, "recon", fake_recon)
+
+    await main_module._cmd_recon(args)
+
+    assert captured["args"] == ("taneda", "1", main_module.DEFAULT_RECON_LOOKAHEAD_DAYS)
+    assert "2026-05-21" in capsys.readouterr().out
 
 
 @pytest.mark.asyncio

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,7 +4,7 @@ import argparse
 import sys, os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from main import _build_inline_task, _build_parser
+from main import _build_inline_task, _build_parser, _should_use_inline_task
 
 
 def test_build_inline_task_uses_date_and_exact_time_flags():
@@ -112,3 +112,53 @@ def test_parser_accepts_cdp_url_for_run():
     ])
 
     assert args.cdp_url == "http://127.0.0.1:9222"
+
+
+def test_build_inline_task_supports_launch_mode_without_date_preferences():
+    args = argparse.Namespace(
+        slug="taneda",
+        size="1",
+        target=None,
+        date=[],
+        exact_time=[],
+        dates=None,
+        exact_times=None,
+        release_at="11:00",
+        newly_released_only=True,
+    )
+
+    task = _build_inline_task(args)
+
+    assert task.size == "1"
+    assert task.launch is not None
+    assert task.launch.newly_released_only is True
+    assert [selector.to_dict() for selector in task.selectors] == [
+        {"dates": []}
+    ]
+
+
+def test_run_uses_inline_launch_task_when_no_dates_are_provided():
+    parser = _build_parser()
+
+    args = parser.parse_args([
+        "run",
+        "taneda",
+        "--size", "1",
+        "--release-at", "11:00",
+        "--newly-released-only",
+    ])
+
+    assert _should_use_inline_task(args) is True
+
+
+def test_snipe_uses_inline_launch_task_when_no_dates_are_provided():
+    parser = _build_parser()
+
+    args = parser.parse_args([
+        "snipe",
+        "taneda",
+        "--release-at", "11:00",
+        "--newly-released-only",
+    ])
+
+    assert _should_use_inline_task(args) is True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,12 @@
 """Unit tests for main.py helpers."""
 
 import argparse
+import logging
+import pytest
 import sys, os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+import main as main_module
 from main import _build_inline_task, _build_parser, _should_use_inline_task
 
 
@@ -112,6 +115,118 @@ def test_parser_accepts_cdp_url_for_run():
     ])
 
     assert args.cdp_url == "http://127.0.0.1:9222"
+
+
+def test_parser_accepts_monitoring_flags_and_date_ranges():
+    parser = _build_parser()
+
+    args = parser.parse_args([
+        "run",
+        "taneda",
+        "--size", "1",
+        "--monitor",
+        "--monitor-duration", "20",
+        "--date-ranges", "2026-05-07:2026-05-09",
+    ])
+
+    assert args.monitor is True
+    assert args.monitor_duration == 20
+    assert args.date_ranges == "2026-05-07:2026-05-09"
+
+
+def test_build_inline_task_expands_date_ranges():
+    args = argparse.Namespace(
+        slug="taneda",
+        size="1",
+        target=None,
+        date=[],
+        dates=None,
+        date_ranges="2026-05-07:2026-05-09",
+        exact_time=[],
+        exact_times=None,
+        release_at=None,
+        newly_released_only=False,
+        monitor=True,
+        monitor_duration=15,
+    )
+
+    task = _build_inline_task(args)
+
+    assert [selector.to_dict() for selector in task.selectors] == [
+        {"dates": ["2026-05-07", "2026-05-08", "2026-05-09"]}
+    ]
+
+
+def test_monitoring_mode_does_not_use_inline_task_without_runtime_support():
+    parser = _build_parser()
+
+    args = parser.parse_args([
+        "snipe",
+        "taneda",
+        "--monitor",
+    ])
+
+    assert _should_use_inline_task(args) is False
+
+
+def test_date_ranges_alone_use_inline_task_mode():
+    parser = _build_parser()
+
+    args = parser.parse_args([
+        "run",
+        "taneda",
+        "--date-ranges", "2026-05-07:2026-05-09",
+    ])
+
+    assert _should_use_inline_task(args) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command", "argv"),
+    [
+        ("run", ["run", "taneda", "--monitor"]),
+        ("snipe", ["snipe", "taneda", "--monitor"]),
+    ],
+)
+async def test_monitor_mode_fails_fast_until_runtime_support(command, argv, monkeypatch, caplog):
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    cmd = getattr(main_module, f"_cmd_{command}")
+
+    async def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("snipe_all should not be called when monitor mode is unsupported")
+
+    monkeypatch.setattr(main_module, "snipe_all", fail_if_called)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(SystemExit) as excinfo:
+            await cmd(args)
+
+    assert excinfo.value.code == 2
+    assert "--monitor is not supported yet" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_invalid_date_ranges_fail_as_cli_error(monkeypatch, caplog):
+    parser = _build_parser()
+    args = parser.parse_args([
+        "run",
+        "taneda",
+        "--date-ranges", "not-a-range",
+    ])
+
+    async def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("snipe_all should not be called for invalid --date-ranges")
+
+    monkeypatch.setattr(main_module, "snipe_all", fail_if_called)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(SystemExit) as excinfo:
+            await main_module._cmd_run(args)
+
+    assert excinfo.value.code == 2
+    assert "Invalid --date-ranges value" in caplog.text
 
 
 def test_build_inline_task_supports_launch_mode_without_date_preferences():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -150,3 +150,18 @@ def test_task_filter_dates_preserves_exact_times():
 
     assert [t.date for t in filtered.expand_targets()] == ["2026-06-18", "2026-06-18"]
     assert [t.exact_time for t in filtered.expand_targets()] == ["5:15 PM", "7:45 PM"]
+
+
+def test_task_filter_dates_expands_empty_date_preferences_to_eligible_dates():
+    from models import Selector
+
+    task = Task(
+        url="taneda",
+        size="1",
+        selectors=[Selector(dates=[])],
+    )
+
+    filtered = task.filter_dates(["2026-05-27", "2026-05-28"])
+
+    assert [t.date for t in filtered.expand_targets()] == ["2026-05-27", "2026-05-28"]
+    assert all(t.earliest_time == "12:00 PM" for t in filtered.expand_targets())

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,7 +4,9 @@ import json
 import sys, os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from models import Target, Task, RESERVATION_TIME_FORMAT
+import pytest
+
+from models import RESERVATION_TIME_FORMAT, Target, Task, expand_date_ranges
 from datetime import datetime
 
 
@@ -13,6 +15,30 @@ def test_target_date_parse():
     assert t.date == "2026-03-15"
     assert t.earliest_dt() == datetime.strptime("5:00 PM", RESERVATION_TIME_FORMAT)
     assert t.latest_dt()   == datetime.strptime("9:30 PM", RESERVATION_TIME_FORMAT)
+
+
+def test_expand_date_ranges_supports_multiple_ranges():
+    dates = expand_date_ranges("2026-05-07:2026-05-09,2026-05-21:2026-05-25")
+    assert dates == [
+        "2026-05-07",
+        "2026-05-08",
+        "2026-05-09",
+        "2026-05-21",
+        "2026-05-22",
+        "2026-05-23",
+        "2026-05-24",
+        "2026-05-25",
+    ]
+
+
+def test_expand_date_ranges_returns_empty_for_blank_input():
+    assert expand_date_ranges(None) == []
+    assert expand_date_ranges("") == []
+
+
+def test_expand_date_ranges_rejects_reversed_ranges():
+    with pytest.raises(ValueError, match="2026-05-09:2026-05-07"):
+        expand_date_ranges("2026-05-09:2026-05-07")
 
 
 def test_target_search_url():

--- a/tests/test_recon.py
+++ b/tests/test_recon.py
@@ -4,9 +4,11 @@ import sys, os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from datetime import datetime
+from urllib.parse import parse_qs, urlparse
 import pytest
 
-from recon import _parse_time, _time_str, _build_tasks
+import recon as recon_module
+from recon import _parse_time, _time_str, _build_tasks, _month_starts_for_lookahead
 from models import Task, Target, RESERVATION_TIME_FORMAT
 
 
@@ -133,6 +135,196 @@ class TestBuildTasks:
         }
         tasks = _build_tasks("alinea", "2", avail)
         assert tasks[0].targets[0].date == "2026-05-20"
+
+
+def test_month_starts_for_lookahead_spans_future_months():
+    starts = _month_starts_for_lookahead("2026-04-18", lookahead_days=60)
+    assert starts == ["2026-04-01", "2026-05-01", "2026-06-01"]
+
+
+class FixedDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2026, 4, 18)
+
+
+class FakeTimeElement:
+    def __init__(self, text):
+        self.text = text
+
+    async def inner_text(self):
+        return self.text
+
+
+class FakeCard:
+    def __init__(self, time_text):
+        self.time_text = time_text
+
+    async def query_selector(self, selector):
+        if selector == "[data-testid='search-result-time']":
+            return FakeTimeElement(self.time_text)
+        return None
+
+
+class FakeDayButton:
+    def __init__(self, page, label):
+        self.page = page
+        self.label = label
+
+    async def get_attribute(self, name):
+        if name == "aria-label":
+            return self.label
+        return None
+
+    async def click(self):
+        self.page.selected_date = self.label
+
+
+class FakePage:
+    def __init__(self, month_data):
+        self.month_data = month_data
+        self.current_month = None
+        self.selected_date = None
+
+    async def goto(self, url, wait_until=None, timeout=None):
+        self.current_month = parse_qs(urlparse(url).query)["date"][0]
+        self.selected_date = None
+
+    async def evaluate(self, script):
+        return None
+
+    async def wait_for_selector(self, selector, timeout=None):
+        return None
+
+    async def wait_for_timeout(self, timeout_ms):
+        return None
+
+    async def query_selector_all(self, selector):
+        current_dates = self.month_data[self.current_month]
+        if selector == "button[data-testid='consumer-calendar-day'][aria-disabled='false']":
+            return [FakeDayButton(self, label) for label in current_dates]
+        if selector == "[data-testid='search-result']":
+            return [FakeCard(slot) for slot in current_dates.get(self.selected_date, [])]
+        return []
+
+
+class FakeBrowser:
+    async def new_context(self, user_agent=None):
+        return object()
+
+    async def close(self):
+        return None
+
+
+class FakeChromium:
+    def __init__(self, browser):
+        self.browser = browser
+
+    async def launch(self, **kwargs):
+        return self.browser
+
+
+class FakePlaywright:
+    def __init__(self, browser):
+        self.chromium = FakeChromium(browser)
+
+
+class FakeAsyncPlaywright:
+    def __init__(self, browser):
+        self.browser = browser
+
+    async def __aenter__(self):
+        return FakePlaywright(self.browser)
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_scrape_restaurant_merges_months_and_filters_to_horizon(monkeypatch):
+    month_data = {
+        "2026-04-01": {
+            "2026-04-17": ["4:30 PM"],
+            "2026-04-18": ["5:15 PM"],
+            "2026-04-30": ["7:45 PM"],
+        },
+        "2026-05-01": {
+            "2026-05-01": ["5:15 PM"],
+            "2026-05-31": ["7:45 PM"],
+        },
+        "2026-06-01": {
+            "2026-06-16": ["5:15 PM"],
+            "2026-06-17": ["7:45 PM"],
+            "2026-06-18": ["9:30 PM"],
+        },
+    }
+    page = FakePage(month_data)
+
+    monkeypatch.setattr(recon_module, "datetime", FixedDateTime)
+    monkeypatch.setattr(recon_module, "async_playwright", lambda: FakeAsyncPlaywright(FakeBrowser()))
+
+    async def fake_new_page(context):
+        return page
+
+    monkeypatch.setattr(recon_module, "_new_stealth_page", fake_new_page)
+
+    availability = await recon_module._scrape_restaurant("taneda", "1", lookahead_days=60)
+
+    assert list(availability) == [
+        "2026-04-18",
+        "2026-04-30",
+        "2026-05-01",
+        "2026-05-31",
+        "2026-06-16",
+        "2026-06-17",
+    ]
+    assert "2026-04-17" not in availability
+    assert "2026-06-18" not in availability
+    assert availability["2026-05-31"]["time_slots"] == ["7:45 PM"]
+
+
+@pytest.mark.asyncio
+async def test_scrape_restaurant_merges_duplicate_dates_across_month_pages(monkeypatch):
+    month_data = {
+        "2026-04-01": {
+            "2026-05-01": ["5:15 PM", "7:45 PM"],
+        },
+        "2026-05-01": {
+            "2026-05-01": ["7:45 PM"],
+        },
+    }
+    page = FakePage(month_data)
+
+    monkeypatch.setattr(recon_module, "datetime", FixedDateTime)
+    monkeypatch.setattr(recon_module, "async_playwright", lambda: FakeAsyncPlaywright(FakeBrowser()))
+
+    async def fake_new_page(context):
+        return page
+
+    monkeypatch.setattr(recon_module, "_new_stealth_page", fake_new_page)
+
+    availability = await recon_module._scrape_restaurant("taneda", "1", lookahead_days=30)
+
+    assert availability["2026-05-01"]["time_slots"] == ["5:15 PM", "7:45 PM"]
+
+
+@pytest.mark.asyncio
+async def test_recon_threads_lookahead_days_into_scrape(monkeypatch):
+    calls = {}
+
+    async def fake_scrape(slug, size, lookahead_days=60):
+        calls["args"] = (slug, size, lookahead_days)
+        return {
+            "2026-04-19": {"time_slots": ["5:15 PM", "7:45 PM"]},
+        }
+
+    monkeypatch.setattr(recon_module, "_scrape_restaurant", fake_scrape)
+    monkeypatch.setattr(recon_module, "_enhance_with_claude", lambda slug, size, raw: None)
+
+    tasks = await recon_module.recon("taneda", size="1", lookahead_days=45)
+
+    assert calls["args"] == ("taneda", "1", 45)
+    assert [target.date for target in tasks[0].targets] == ["2026-04-19"]
 
 
 # ── _parse_next_data_json tests ──────────────────────────────────────────────

--- a/tests/test_sniper.py
+++ b/tests/test_sniper.py
@@ -9,6 +9,7 @@ import asyncio
 import time
 import warnings
 import sys, os
+from datetime import datetime
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import pytest
@@ -537,6 +538,24 @@ def test_newly_released_dates_applies_delta_and_filter():
     )
 
     assert result == ["2026-06-17"]
+
+
+class FixedDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2026, 4, 18)
+
+
+def test_default_launch_window_dates_uses_next_30_calendar_days(monkeypatch):
+    from sniper import _default_launch_window_dates
+
+    monkeypatch.setattr("sniper.datetime", FixedDateTime)
+
+    assert _default_launch_window_dates(3) == [
+        "2026-04-18",
+        "2026-04-19",
+        "2026-04-20",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_sniper.py
+++ b/tests/test_sniper.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from models import Selector, Task, Target
+from models import LaunchConfig, Selector, Task, Target
 from sniper import DayWorker
 
 
@@ -540,6 +540,64 @@ def test_newly_released_dates_applies_delta_and_filter():
 
 
 @pytest.mark.asyncio
+async def test_launch_mode_does_not_exit_after_first_empty_new_release_diff():
+    from sniper import _monitor_newly_released_dates
+
+    task = Task(url="taneda", size="1", selectors=[
+        Selector(dates=["2026-05-21"]),
+    ])
+    page = AsyncMock()
+
+    with patch(
+        "sniper._capture_available_dates",
+        AsyncMock(side_effect=[
+            {"2026-05-01"},
+            {"2026-05-01", "2026-05-21"},
+        ]),
+    ) as capture_mock:
+        with patch("sniper.asyncio.sleep", AsyncMock()) as sleep_mock:
+            result = await _monitor_newly_released_dates(
+                page,
+                task,
+                requested_dates=["2026-05-21"],
+                interval=5.0,
+                deadline=asyncio.get_running_loop().time() + 60,
+                baseline_dates={"2026-05-01"},
+            )
+
+    assert result == ["2026-05-21"]
+    assert capture_mock.await_count == 2
+    sleep_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_monitor_newly_released_dates_returns_empty_after_deadline():
+    from sniper import _monitor_newly_released_dates
+
+    task = Task(url="taneda", size="1", selectors=[
+        Selector(dates=["2026-05-21"]),
+    ])
+    page = AsyncMock()
+
+    with patch(
+        "sniper._capture_available_dates",
+        AsyncMock(return_value={"2026-05-01"}),
+    ):
+        with patch("sniper.asyncio.sleep", AsyncMock()) as sleep_mock:
+            result = await _monitor_newly_released_dates(
+                page,
+                task,
+                requested_dates=["2026-05-21"],
+                interval=5.0,
+                deadline=asyncio.get_running_loop().time(),
+                baseline_dates={"2026-05-01"},
+            )
+
+    assert result == []
+    sleep_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_open_browser_context_uses_cdp_when_url_provided():
     from sniper import _open_browser_context
 
@@ -679,6 +737,222 @@ async def test_snipe_task_does_not_close_attached_cdp_browser():
     browser.close.assert_not_awaited()
     context.close.assert_not_awaited()
     page.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_snipe_task_cleans_up_stragglers_after_found_event_before_browser_close():
+    from sniper import snipe_task
+
+    order = []
+    browser = AsyncMock()
+    context = AsyncMock()
+    winner_page = AsyncMock()
+    straggler_page = AsyncMock()
+    context.new_page = AsyncMock(side_effect=[winner_page, straggler_page])
+
+    async def _close_browser():
+        order.append("browser.close")
+
+    browser.close = AsyncMock(side_effect=_close_browser)
+
+    class FakeWorker:
+        instances = []
+
+        def __init__(self, task, target, page, found_event, dry_run=False, interval=30.0, prompt_login=False):
+            self.task = task
+            self.target = target
+            self.page = page
+            self.found_event = found_event
+            self.checkout_url = None
+            self.matched_time = None
+            FakeWorker.instances.append(self)
+
+        async def run(self):
+            if self.page is winner_page:
+                self.checkout_url = "(dry-run)"
+                self.found_event.set()
+                order.append("winner.done")
+                return None
+
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                order.append("straggler.cancelled")
+                raise
+
+    with patch("sniper.async_playwright", return_value=_FakePlaywrightContextManager(AsyncMock())):
+        with patch("sniper._open_browser_context", AsyncMock(return_value=(browser, context, True, True))):
+            with patch("sniper._apply_stealth", AsyncMock()):
+                with patch("sniper.DayWorker", FakeWorker):
+                    task = Task(url="alinea", size="2", selectors=[
+                        Selector(
+                            dates=["2026-03-15", "2026-03-16"],
+                            earliest_time="5:00 PM",
+                            latest_time="9:30 PM",
+                        ),
+                    ])
+
+                    result = await snipe_task(task, dry_run=True)
+
+    assert result == {
+        "restaurant": "alinea",
+        "date": "2026-03-15",
+        "time": "",
+        "checkout_url": "(dry-run)",
+    }
+    assert order == ["winner.done", "straggler.cancelled", "browser.close"]
+
+
+@pytest.mark.asyncio
+async def test_snipe_task_monitoring_deadline_cancels_workers_before_browser_close():
+    from sniper import snipe_task
+
+    order = []
+    browser = AsyncMock()
+    context = AsyncMock()
+    page = AsyncMock()
+    context.new_page = AsyncMock(return_value=page)
+
+    async def _close_browser():
+        order.append("browser.close")
+
+    browser.close = AsyncMock(side_effect=_close_browser)
+
+    class FakeWorker:
+        def __init__(self, task, target, page, found_event, dry_run=False, interval=30.0, prompt_login=False):
+            self.task = task
+            self.target = target
+            self.page = page
+            self.checkout_url = None
+
+        async def run(self):
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                order.append("worker.cancelled")
+                raise
+
+    with patch("sniper.async_playwright", return_value=_FakePlaywrightContextManager(AsyncMock())):
+        with patch("sniper._open_browser_context", AsyncMock(return_value=(browser, context, True, True))):
+            with patch("sniper._apply_stealth", AsyncMock()):
+                with patch("sniper.DayWorker", FakeWorker):
+                    task = Task(url="alinea", size="2", selectors=[
+                        Selector(
+                            dates=["2026-03-15"],
+                            earliest_time="5:00 PM",
+                            latest_time="9:30 PM",
+                        ),
+                    ])
+
+                    result = await snipe_task(
+                        task,
+                        dry_run=True,
+                        monitor=True,
+                        monitor_duration=0.001,
+                    )
+
+    assert result is None
+    assert order == ["worker.cancelled", "browser.close"]
+
+
+@pytest.mark.asyncio
+async def test_snipe_task_launch_monitoring_retries_until_new_dates_found():
+    from sniper import snipe_task
+
+    browser = AsyncMock()
+    context = AsyncMock()
+    scout = AsyncMock()
+    worker_page = AsyncMock()
+    context.new_page = AsyncMock(side_effect=[scout, worker_page])
+
+    class FakeWorker:
+        created_targets = []
+
+        def __init__(self, task, target, page, found_event, dry_run=False, interval=30.0, prompt_login=False):
+            self.task = task
+            self.target = target
+            self.page = page
+            self.checkout_url = "(dry-run)"
+            self.matched_time = target.exact_time or target.earliest_time
+            FakeWorker.created_targets.append(target.date)
+
+        async def run(self):
+            return None
+
+    task = Task(
+        url="taneda",
+        size="1",
+        selectors=[Selector(dates=["2026-05-21"], exact_times=["5:15 PM"])],
+        launch=LaunchConfig(release_at="11:00", newly_released_only=True),
+    )
+    FakeWorker.created_targets = []
+
+    with patch("sniper.async_playwright", return_value=_FakePlaywrightContextManager(AsyncMock())):
+        with patch("sniper._open_browser_context", AsyncMock(return_value=(browser, context, True, True))):
+            with patch("sniper._apply_stealth", AsyncMock()):
+                with patch("sniper._wait_for_release", AsyncMock()):
+                    with patch("sniper.DayWorker", FakeWorker):
+                        with patch(
+                            "sniper._capture_available_dates",
+                            AsyncMock(side_effect=[
+                                {"2026-05-01"},
+                                {"2026-05-01"},
+                                {"2026-05-01", "2026-05-21"},
+                            ]),
+                        ):
+                            with patch("sniper.asyncio.sleep", AsyncMock()):
+                                result = await snipe_task(task, dry_run=True, interval=5.0)
+
+    assert result == {
+        "restaurant": "taneda",
+        "date": "2026-05-21",
+        "time": "5:15 PM",
+        "checkout_url": "(dry-run)",
+    }
+    assert FakeWorker.created_targets == ["2026-05-21"]
+
+
+@pytest.mark.asyncio
+async def test_snipe_all_forwards_monitoring_kwargs():
+    from sniper import snipe_all
+
+    task = Task(url="alinea", size="2", selectors=[
+        Selector(
+            dates=["2026-03-15"],
+            earliest_time="5:00 PM",
+            latest_time="9:30 PM",
+        ),
+    ])
+
+    with patch(
+        "sniper.snipe_task",
+        AsyncMock(return_value={
+            "restaurant": "alinea",
+            "date": "2026-03-15",
+            "time": "7:00 PM",
+            "checkout_url": "(dry-run)",
+        }),
+    ) as snipe_task_mock:
+        results = await snipe_all(
+            [task],
+            dry_run=True,
+            monitor=True,
+            monitor_duration=3.5,
+        )
+
+    snipe_task_mock.assert_awaited_once_with(
+        task,
+        dry_run=True,
+        monitor=True,
+        monitor_duration=3.5,
+    )
+    assert results == [{
+        "status": "success",
+        "restaurant": "alinea",
+        "date": "2026-03-15",
+        "time": "7:00 PM",
+        "checkout_url": "(dry-run)",
+    }]
 
 
 # ── _poll() with __NEXT_DATA__ pre-filter tests ─────────────────────────────


### PR DESCRIPTION
## Summary

- Expand recon to scan forward across the next 60 days instead of the current month only; dedupe time slots when the same date appears in adjacent month views.
- Add persistent monitoring loops: `--monitor` / `--monitor-duration` keeps polling for restocks and cancellations; launch mode now monitors after `--release-at` instead of making a single before/after diff.
- Add `--date-ranges` for compact day-window input (e.g. `2026-05-07:2026-05-09,2026-05-21:2026-05-25`) and allow launch mode without explicit dates (defaults to next 30 days).
- Wire monitoring and forward-window flags through `snipe` and `run` subcommands; update README with the new defaults and usage examples.

## Test plan

- [ ] `pytest` — `tests/test_main.py`, `tests/test_models.py`, `tests/test_recon.py`, `tests/test_sniper.py`
- [ ] Manual `python main.py recon taneda --size 1` confirms multi-month sweep
- [ ] Manual `python main.py run taneda --size 1 --monitor --monitor-duration 5 --interval 10 --dry-run` confirms persistent loop and clean timeout

Generated with [Claude Code](https://claude.com/claude-code)